### PR TITLE
Fixed #664: better 404 not found error handling.

### DIFF
--- a/internal/app/handlers/base.go
+++ b/internal/app/handlers/base.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/locale"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 	"github.com/ugent-library/biblio-backend/internal/render/flash"
 	"go.uber.org/zap"
 )
@@ -74,7 +73,7 @@ func (h BaseHandler) Wrap(fn func(http.ResponseWriter, *http.Request, BaseContex
 		ctx, err := h.NewContext(r, w)
 		if err != nil {
 			h.Logger.Errorw("could not create new context.", err)
-			render.InternalServerError(w, r, err)
+			InternalServerError(w, r, err)
 			return
 		}
 		fn(w, r, ctx)

--- a/internal/app/handlers/dashboard/datasets.go
+++ b/internal/app/handlers/dashboard/datasets.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/models"
 	"github.com/ugent-library/biblio-backend/internal/render"
@@ -49,7 +50,7 @@ func (h *Handler) Datasets(w http.ResponseWriter, r *http.Request, ctx Context) 
 
 	if err != nil {
 		h.Logger.Errorw("Dashboard: could not execute search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/dashboard/handler.go
+++ b/internal/app/handlers/dashboard/handler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -23,7 +22,7 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil || !ctx.User.CanViewDashboard() {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 

--- a/internal/app/handlers/dashboard/publications.go
+++ b/internal/app/handlers/dashboard/publications.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/app/localize"
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/models"
@@ -58,7 +59,7 @@ func (h *Handler) Publications(w http.ResponseWriter, r *http.Request, ctx Conte
 
 	if err != nil {
 		h.Logger.Errorw("Dashboard: could not execute search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -73,7 +74,7 @@ func (h *Handler) Publications(w http.ResponseWriter, r *http.Request, ctx Conte
 
 	if err != nil {
 		h.Logger.Errorw("Dashboard: could not execute search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetcreating/handler.go
+++ b/internal/app/handlers/datasetcreating/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -25,7 +24,7 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
@@ -36,13 +35,13 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 		if id := bind.PathValues(r).Get("id"); id != "" {
 			d, err := h.Repository.GetDataset(id)
 			if err != nil {
-				render.NotFound(w, r, err)
+				handlers.NotFound(w, r, ctx, err)
 				return
 			}
 
 			if !ctx.User.CanEditDataset(d) {
 				h.Logger.Warn("create dataset: user isn't allowed to edit the dataset:", "error", err, "dataset", id, "user", ctx.User.ID)
-				render.Forbidden(w, r)
+				handlers.Forbidden(w, r)
 				return
 			}
 

--- a/internal/app/handlers/datasetcreating/import.go
+++ b/internal/app/handlers/datasetcreating/import.go
@@ -61,7 +61,7 @@ func (h *Handler) ConfirmImport(w http.ResponseWriter, r *http.Request, ctx Cont
 	b := BindImport{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("confirm import dataset: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -73,7 +73,7 @@ func (h *Handler) ConfirmImport(w http.ResponseWriter, r *http.Request, ctx Cont
 
 		if err != nil {
 			h.Logger.Errorw("confirm import dataset: could not execute search", "errors", err, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 
@@ -99,7 +99,7 @@ func (h *Handler) AddImport(w http.ResponseWriter, r *http.Request, ctx Context)
 	b := BindImport{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("add import dataset: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -156,7 +156,7 @@ func (h *Handler) AddImport(w http.ResponseWriter, r *http.Request, ctx Context)
 
 	if err != nil {
 		h.Logger.Warnw("add import dataset: could not save dataset:", "errors", err, "dataset", b.Identifier, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (h *Handler) AddConfirm(w http.ResponseWriter, r *http.Request, ctx Context
 func (h *Handler) AddPublish(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanEditDataset(ctx.Dataset) {
 		h.Logger.Warn("publish dataset: user isn't allowed to edit the dataset:", "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -238,7 +238,7 @@ func (h *Handler) AddPublish(w http.ResponseWriter, r *http.Request, ctx Context
 	}
 
 	if err != nil {
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		h.Logger.Warnf("create dataset: Could not save the dataset:", "error", err, "identifier", ctx.Dataset.ID)
 		return
 	}

--- a/internal/app/handlers/datasetediting/abstract.go
+++ b/internal/app/handlers/datasetediting/abstract.go
@@ -61,7 +61,7 @@ func (h *Handler) CreateAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("create dataset abstract: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -95,7 +95,7 @@ func (h *Handler) CreateAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 
 	if err != nil {
 		h.Logger.Errorf("create dataset abstract: could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -108,7 +108,7 @@ func (h *Handler) EditAbstract(w http.ResponseWriter, r *http.Request, ctx Conte
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("edit dataset abstract: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -135,7 +135,7 @@ func (h *Handler) UpdateAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 	b := BindAbstract{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("update dataset abstract: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -186,7 +186,7 @@ func (h *Handler) UpdateAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 
 	if err != nil {
 		h.Logger.Warnf("update dataset abstract: Could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -199,7 +199,7 @@ func (h *Handler) ConfirmDeleteAbstract(w http.ResponseWriter, r *http.Request, 
 	var b BindDeleteAbstract
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete dataset: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -221,7 +221,7 @@ func (h *Handler) DeleteAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 	var b BindDeleteAbstract
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete datase abstract: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -239,7 +239,7 @@ func (h *Handler) DeleteAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 
 	if err != nil {
 		h.Logger.Warnf("delete dataset abstract: Could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/activity.go
+++ b/internal/app/handlers/datasetediting/activity.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/app/localize"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/locale"
@@ -55,7 +56,7 @@ func (h *Handler) UpdateMessage(w http.ResponseWriter, r *http.Request, ctx Cont
 	b := BindMessage{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update dataset reviewer note: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -86,7 +87,7 @@ func (h *Handler) UpdateMessage(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorf("update dataset message: could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -95,7 +96,7 @@ func (h *Handler) UpdateMessage(w http.ResponseWriter, r *http.Request, ctx Cont
 
 func (h *Handler) EditReviewerTags(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
@@ -107,14 +108,14 @@ func (h *Handler) EditReviewerTags(w http.ResponseWriter, r *http.Request, ctx C
 
 func (h *Handler) UpdateReviewerTags(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
 	b := BindReviewerTags{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update dataset reviewer tags: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -145,7 +146,7 @@ func (h *Handler) UpdateReviewerTags(w http.ResponseWriter, r *http.Request, ctx
 
 	if err != nil {
 		h.Logger.Errorf("update dataset reviewer tags: could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -154,7 +155,7 @@ func (h *Handler) UpdateReviewerTags(w http.ResponseWriter, r *http.Request, ctx
 
 func (h *Handler) EditReviewerNote(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
@@ -167,14 +168,14 @@ func (h *Handler) EditReviewerNote(w http.ResponseWriter, r *http.Request, ctx C
 
 func (h *Handler) UpdateReviewerNote(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
 	b := BindReviewerNote{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update dataset reviewer note: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -205,7 +206,7 @@ func (h *Handler) UpdateReviewerNote(w http.ResponseWriter, r *http.Request, ctx
 
 	if err != nil {
 		h.Logger.Errorf("update dataset reviewer note: could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/contributors.go
+++ b/internal/app/handlers/datasetediting/contributors.go
@@ -153,7 +153,7 @@ func (h *Handler) AddContributor(w http.ResponseWriter, r *http.Request, ctx Con
 	b := BindAddContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("add dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -166,7 +166,7 @@ func (h *Handler) AddContributor(w http.ResponseWriter, r *http.Request, ctx Con
 		hits, err = h.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
 			h.Logger.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 	}
@@ -191,7 +191,7 @@ func (h *Handler) AddContributorSuggest(w http.ResponseWriter, r *http.Request, 
 	b := BindAddContributorSuggest{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("suggest dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -204,7 +204,7 @@ func (h *Handler) AddContributorSuggest(w http.ResponseWriter, r *http.Request, 
 		hits, err = h.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
 			h.Logger.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 	}
@@ -226,7 +226,7 @@ func (h *Handler) ConfirmCreateContributor(w http.ResponseWriter, r *http.Reques
 	b := BindConfirmCreateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("confirm create dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -235,7 +235,7 @@ func (h *Handler) ConfirmCreateContributor(w http.ResponseWriter, r *http.Reques
 	if b.ID != "" {
 		newC, newP, err := h.generateContributorFromPersonId(b.ID)
 		if err != nil {
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		c = newC
@@ -258,7 +258,7 @@ func (h *Handler) CreateContributor(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindCreateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("create dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -267,7 +267,7 @@ func (h *Handler) CreateContributor(w http.ResponseWriter, r *http.Request, ctx 
 	if b.ID != "" {
 		newC, newP, err := h.generateContributorFromPersonId(b.ID)
 		if err != nil {
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		c = newC
@@ -303,7 +303,7 @@ func (h *Handler) CreateContributor(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorf("create dataset contributor: Could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -332,14 +332,14 @@ func (h *Handler) EditContributor(w http.ResponseWriter, r *http.Request, ctx Co
 	b := BindEditContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("edit dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	c, err := ctx.Dataset.GetContributor(b.Role, b.Position)
 	if err != nil {
 		h.Logger.Errorw("edit dataset contributor: could not get the contributor", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -347,7 +347,7 @@ func (h *Handler) EditContributor(w http.ResponseWriter, r *http.Request, ctx Co
 	if c.ID != "" {
 		p, err := h.PersonService.GetPerson(c.ID)
 		if err != nil {
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		active = p.Active
@@ -363,7 +363,7 @@ func (h *Handler) EditContributor(w http.ResponseWriter, r *http.Request, ctx Co
 	hits, err := h.PersonSearchService.SuggestPeople(firstName + " " + lastName)
 	if err != nil {
 		h.Logger.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -400,14 +400,14 @@ func (h *Handler) EditContributorSuggest(w http.ResponseWriter, r *http.Request,
 	b := BindEditContributorSuggest{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("suggest dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	c, err := ctx.Dataset.GetContributor(b.Role, b.Position)
 	if err != nil {
 		h.Logger.Errorw("edit dataset contributor: could not get the contributor", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -417,7 +417,7 @@ func (h *Handler) EditContributorSuggest(w http.ResponseWriter, r *http.Request,
 		hits, err = h.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
 			h.Logger.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 
@@ -447,7 +447,7 @@ func (h *Handler) ConfirmUpdateContributor(w http.ResponseWriter, r *http.Reques
 	b := BindConfirmUpdateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("confirm update dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -456,7 +456,7 @@ func (h *Handler) ConfirmUpdateContributor(w http.ResponseWriter, r *http.Reques
 	if b.ID != "" {
 		newC, newP, err := h.generateContributorFromPersonId(b.ID)
 		if err != nil {
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		c = newC
@@ -481,7 +481,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindUpdateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -491,7 +491,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 		newC, newP, err := h.generateContributorFromPersonId(b.ID)
 		if err != nil {
 			h.Logger.Errorw("update dataset contributor: could not fetch person", "errors", err, "personid", b.ID, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		c = newC
@@ -503,7 +503,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err := ctx.Dataset.SetContributor(b.Role, b.Position, c); err != nil {
 		h.Logger.Errorw("update dataset contributor: could not set the contributor", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -533,7 +533,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorf("update dataset contributor: Could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -543,7 +543,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 		hits, err := h.PersonSearchService.SuggestPeople(nextC.FirstName + " " + nextC.LastName)
 		if err != nil {
 			h.Logger.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 
@@ -553,7 +553,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 		if nextC.ID != "" {
 			p, err := h.PersonService.GetPerson(nextC.ID)
 			if err != nil {
-				render.InternalServerError(w, r, err)
+				handlers.InternalServerError(w, r, err)
 				return
 			}
 			nextActive = p.Active
@@ -584,7 +584,7 @@ func (h *Handler) ConfirmDeleteContributor(w http.ResponseWriter, r *http.Reques
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -599,13 +599,13 @@ func (h *Handler) DeleteContributor(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	if err := ctx.Dataset.RemoveContributor(b.Role, b.Position); err != nil {
 		h.Logger.Warnw("delete dataset contributor: could not remove contributor", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -634,7 +634,7 @@ func (h *Handler) DeleteContributor(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorf("delete dataset contributor: Could not save the dataset:", "error", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -648,7 +648,7 @@ func (h *Handler) OrderContributors(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindOrderContributors{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("order dataset contributors: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -656,7 +656,7 @@ func (h *Handler) OrderContributors(w http.ResponseWriter, r *http.Request, ctx 
 	if len(b.Positions) != len(contributors) {
 		err := fmt.Errorf("positions don't match number of contributors")
 		h.Logger.Warnw("order dataset contributors: could not order contributors", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 	newContributors := make([]*models.Contributor, len(contributors))
@@ -677,7 +677,7 @@ func (h *Handler) OrderContributors(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorf("order dataset contributors: Could not save the dataset:", "errors", err, "identifier", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/delete.go
+++ b/internal/app/handlers/datasetediting/delete.go
@@ -30,7 +30,7 @@ func (h *Handler) ConfirmDelete(w http.ResponseWriter, r *http.Request, ctx Cont
 func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanDeleteDataset(ctx.Dataset) {
 		h.Logger.Warnw("delete dataset: user isn't allowed to delete dataset", "dataset", ctx.Dataset.ID, "user", ctx.User.ID, "user", ctx.User.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -48,7 +48,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, ctx Context) {
 
 	if err != nil {
 		h.Logger.Errorf("delete dataset: Could not save the dataset:", "error", err, "identifier", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/department.go
+++ b/internal/app/handlers/datasetediting/department.go
@@ -42,7 +42,7 @@ func (h *Handler) AddDepartment(w http.ResponseWriter, r *http.Request, ctx Cont
 	hits, err := h.OrganizationSearchService.SuggestOrganizations("")
 	if err != nil {
 		h.Logger.Errorw("add dataset department: could not suggest organization", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -56,14 +56,14 @@ func (h *Handler) SuggestDepartments(w http.ResponseWriter, r *http.Request, ctx
 	b := BindSuggestDepartments{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("suggest dataset departments could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	hits, err := h.OrganizationSearchService.SuggestOrganizations(b.Query)
 	if err != nil {
 		h.Logger.Errorw("add dataset department: could not suggest organization", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -77,14 +77,14 @@ func (h *Handler) CreateDepartment(w http.ResponseWriter, r *http.Request, ctx C
 	b := BindDepartment{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("create dataset department: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	org, err := h.OrganizationService.GetOrganization(b.DepartmentID)
 	if err != nil {
 		h.Logger.Errorw("create dataset department: could not find organization", "errors", err, "dataset", ctx.Dataset.ID, "department", b.DepartmentID, r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -104,7 +104,7 @@ func (h *Handler) CreateDepartment(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("create dataset department: Could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -117,7 +117,7 @@ func (h *Handler) ConfirmDeleteDepartment(w http.ResponseWriter, r *http.Request
 	b := BindDeleteDepartment{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete dataset department: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -138,7 +138,7 @@ func (h *Handler) DeleteDepartment(w http.ResponseWriter, r *http.Request, ctx C
 	var b BindDeleteDepartment
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete dataset department: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -156,7 +156,7 @@ func (h *Handler) DeleteDepartment(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("delete dataset department: Could not save the dataset:", "error", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/details.go
+++ b/internal/app/handlers/datasetediting/details.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ugent-library/biblio-backend/internal/app/displays"
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/app/localize"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/locale"
@@ -52,7 +53,7 @@ func (h *Handler) RefreshEditFileForm(w http.ResponseWriter, r *http.Request, ct
 	b := BindDetails{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update dataset details: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -84,7 +85,7 @@ func (h *Handler) UpdateDetails(w http.ResponseWriter, r *http.Request, ctx Cont
 	b := BindDetails{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update dataset details: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -130,7 +131,7 @@ func (h *Handler) UpdateDetails(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorf("update dataset details: Could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/handler.go
+++ b/internal/app/handlers/datasetediting/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -30,7 +29,7 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
@@ -38,16 +37,16 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 		d, err := h.Repository.GetDataset(id)
 		if err != nil {
 			if err == backends.ErrNotFound {
-				render.NotFound(w, r, err)
+				handlers.NotFound(w, r, ctx, err)
 			} else {
-				render.InternalServerError(w, r, err)
+				handlers.InternalServerError(w, r, err)
 			}
 			return
 		}
 
 		if !ctx.User.CanEditDataset(d) {
 			h.Logger.Warn("edit dataset: user isn't allowed to edit the dataset:", "error", err, "dataset", id, "user", ctx.User.ID)
-			render.Forbidden(w, r)
+			handlers.Forbidden(w, r)
 			return
 		}
 

--- a/internal/app/handlers/datasetediting/lock.go
+++ b/internal/app/handlers/datasetediting/lock.go
@@ -22,7 +22,7 @@ type YieldLock struct {
 func (h *Handler) Lock(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
 		h.Logger.Warnw("lock dataset: user has no permission to lock", "user", ctx.User.ID, "dataset", ctx.Dataset.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -52,7 +52,7 @@ func (h *Handler) Lock(w http.ResponseWriter, r *http.Request, ctx Context) {
 
 	if err != nil {
 		h.Logger.Errorf("lock dataset: could not save the dataset:", "error", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -68,7 +68,7 @@ func (h *Handler) Lock(w http.ResponseWriter, r *http.Request, ctx Context) {
 func (h *Handler) Unlock(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
 		h.Logger.Warnw("unlock dataset: user has no permission to lock", "user", ctx.User.ID, "dataset", ctx.Dataset.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -99,7 +99,7 @@ func (h *Handler) Unlock(w http.ResponseWriter, r *http.Request, ctx Context) {
 
 	if err != nil {
 		h.Logger.Errorf("unlock dataset: could not save the dataset:", "error", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/project.go
+++ b/internal/app/handlers/datasetediting/project.go
@@ -38,7 +38,7 @@ func (h *Handler) AddProject(w http.ResponseWriter, r *http.Request, ctx Context
 	hits, err := h.ProjectSearchService.SuggestProjects("")
 	if err != nil {
 		h.Logger.Errorw("add dataset project: could not suggest projects:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -52,14 +52,14 @@ func (h *Handler) SuggestProjects(w http.ResponseWriter, r *http.Request, ctx Co
 	b := BindSuggestProjects{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("suggest dataset project: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	hits, err := h.ProjectSearchService.SuggestProjects(b.Query)
 	if err != nil {
 		h.Logger.Errorw("suggest dataset project: could not suggest projects:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -73,14 +73,14 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request, ctx Cont
 	b := BindProject{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("create dataset project: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	project, err := h.ProjectService.GetProject(b.ProjectID)
 	if err != nil {
 		h.Logger.Errorw("create dataset project: could not get project:", "errors", err, "dataset", ctx.Dataset.ID, "project", b.ProjectID, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -107,7 +107,7 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorf("create dataset project: Could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -120,7 +120,7 @@ func (h *Handler) ConfirmDeleteProject(w http.ResponseWriter, r *http.Request, c
 	b := BindDeleteProject{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete dataset project: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -141,7 +141,7 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request, ctx Cont
 	var b BindDeleteProject
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete dataset project: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -161,7 +161,7 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorf("delete dataset project: Could not save the dataset:", "error", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/publication.go
+++ b/internal/app/handlers/datasetediting/publication.go
@@ -37,7 +37,7 @@ func (h *Handler) AddPublication(w http.ResponseWriter, r *http.Request, ctx Con
 	hits, err := h.searchRelatedPublications(ctx.User, ctx.Dataset, "")
 	if err != nil {
 		h.Logger.Errorf("add dataset publication: Could find related publications:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -51,14 +51,14 @@ func (h *Handler) SuggestPublications(w http.ResponseWriter, r *http.Request, ct
 	b := BindSuggestPublications{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("suggest dataset publications: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	hits, err := h.searchRelatedPublications(ctx.User, ctx.Dataset, b.Query)
 	if err != nil {
 		h.Logger.Errorf("add dataset publication: Could find related publications:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -72,7 +72,7 @@ func (h *Handler) CreatePublication(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindPublication{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("create dataset publication: could not bind request arguments", "errors", err, "request", r)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -80,7 +80,7 @@ func (h *Handler) CreatePublication(w http.ResponseWriter, r *http.Request, ctx 
 	p, err := h.Repository.GetPublication(b.PublicationID)
 	if err != nil {
 		h.Logger.Errorw("create dataset publication: could not get the publication", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -92,14 +92,14 @@ func (h *Handler) CreatePublication(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorw("create dataset publication: could not add the publication", "error", err, "dataset", ctx.Dataset.ID, "publication", p.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
 	relatedPublications, err := h.Repository.GetVisibleDatasetPublications(ctx.User, ctx.Dataset)
 	if err != nil {
 		h.Logger.Errorw("create dataset publication: could not get dataset publications", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -113,7 +113,7 @@ func (h *Handler) ConfirmDeletePublication(w http.ResponseWriter, r *http.Reques
 	b := BindDeletePublication{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete dataset publication: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -134,7 +134,7 @@ func (h *Handler) DeletePublication(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindDeletePublication{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete dataset publication: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -142,7 +142,7 @@ func (h *Handler) DeletePublication(w http.ResponseWriter, r *http.Request, ctx 
 	p, err := h.Repository.GetPublication(b.PublicationID)
 	if err != nil {
 		h.Logger.Errorw("delete dataset publication: could not get the publication", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -153,7 +153,7 @@ func (h *Handler) DeletePublication(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorw("delete dataset publication: could not delete the publication", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -161,14 +161,14 @@ func (h *Handler) DeletePublication(w http.ResponseWriter, r *http.Request, ctx 
 	ctx.Dataset, err = h.Repository.GetDataset(ctx.Dataset.ID)
 	if err != nil {
 		h.Logger.Errorw("delete dataset publication: could not get the dataset", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
 	relatedPublications, err := h.Repository.GetVisibleDatasetPublications(ctx.User, ctx.Dataset)
 	if err != nil {
 		h.Logger.Errorw("create dataset publication: could not get dataset publications", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/publish.go
+++ b/internal/app/handlers/datasetediting/publish.go
@@ -29,7 +29,7 @@ func (h *Handler) ConfirmPublish(w http.ResponseWriter, r *http.Request, ctx Con
 func (h *Handler) Publish(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanEditDataset(ctx.Dataset) {
 		h.Logger.Warnw("publish dataset: user has no permission to publish", "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -60,7 +60,7 @@ func (h *Handler) Publish(w http.ResponseWriter, r *http.Request, ctx Context) {
 
 	if err != nil {
 		h.Logger.Errorf("publish dataset: could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/republish.go
+++ b/internal/app/handlers/datasetediting/republish.go
@@ -29,7 +29,7 @@ func (h *Handler) ConfirmRepublish(w http.ResponseWriter, r *http.Request, ctx C
 func (h *Handler) Republish(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanEditDataset(ctx.Dataset) {
 		h.Logger.Warnw("republish dataset: user has no permission to republish", "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -60,7 +60,7 @@ func (h *Handler) Republish(w http.ResponseWriter, r *http.Request, ctx Context)
 
 	if err != nil {
 		h.Logger.Errorf("republish dataset: could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetediting/withdraw.go
+++ b/internal/app/handlers/datasetediting/withdraw.go
@@ -29,7 +29,7 @@ func (h *Handler) ConfirmWithdraw(w http.ResponseWriter, r *http.Request, ctx Co
 func (h *Handler) Withdraw(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanEditDataset(ctx.Dataset) {
 		h.Logger.Warnw("withdraw dataset: user has no permission to withdraw", "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -60,7 +60,7 @@ func (h *Handler) Withdraw(w http.ResponseWriter, r *http.Request, ctx Context) 
 
 	if err != nil {
 		h.Logger.Errorf("withdraw dataset: could not save the dataset:", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetexporting/export.go
+++ b/internal/app/handlers/datasetexporting/export.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 func (h *Handler) ExportByCurationSearch(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -23,7 +23,7 @@ func (h *Handler) ExportByCurationSearch(w http.ResponseWriter, r *http.Request,
 			"errors", e,
 			"user", ctx.User.ID,
 		)
-		render.InternalServerError(w, r, e)
+		handlers.InternalServerError(w, r, e)
 		return
 	}
 	exporter := exporterFactory(w)
@@ -39,7 +39,7 @@ func (h *Handler) ExportByCurationSearch(w http.ResponseWriter, r *http.Request,
 			"errors", searcherErr,
 			"user", ctx.User.ID,
 		)
-		render.InternalServerError(w, r, fmt.Errorf("unable to execute search"))
+		handlers.InternalServerError(w, r, fmt.Errorf("unable to execute search"))
 		return
 	}
 
@@ -60,7 +60,7 @@ func (h *Handler) ExportByCurationSearch(w http.ResponseWriter, r *http.Request,
 
 	if err := exporter.Flush(); err != nil {
 		h.Logger.Errorw("dataset search: could not export search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/datasetexporting/handler.go
+++ b/internal/app/handlers/datasetexporting/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -29,21 +28,21 @@ type ExportArgs struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
 		searchArgs := models.NewSearchArgs()
 		if err := bind.Request(r, searchArgs); err != nil {
 			h.Logger.Warnw("publication search: could not bind search arguments", "errors", err, "request", r, "user", ctx.User.ID)
-			render.BadRequest(w, r, err)
+			handlers.BadRequest(w, r, err)
 			return
 		}
 
 		exportArgs := &ExportArgs{}
 		if err := bind.Request(r, exportArgs); err != nil {
 			h.Logger.Warnw("publication search: could not bind export arguments", "errors", err, "request", r, "user", ctx.User.ID)
-			render.BadRequest(w, r, err)
+			handlers.BadRequest(w, r, err)
 			return
 		}
 		if exportArgs.Format == "" {

--- a/internal/app/handlers/datasetsearching/handler.go
+++ b/internal/app/handlers/datasetsearching/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -23,14 +22,14 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
 		searchArgs := models.NewSearchArgs()
 		if err := bind.Request(r, searchArgs); err != nil {
 			h.Logger.Warnw("dataset search: could not bind search arguments", "errors", err, "request", r, "user", ctx.User.ID)
-			render.BadRequest(w, r, err)
+			handlers.BadRequest(w, r, err)
 			return
 		}
 		searchArgs.Cleanup()

--- a/internal/app/handlers/datasetsearching/search.go
+++ b/internal/app/handlers/datasetsearching/search.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
@@ -61,7 +62,7 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request, ctx Context) {
 	default:
 		errorUnkownScope := fmt.Errorf("unknown scope: %s", args.FilterFor("scope"))
 		h.Logger.Warnw("dataset search: could not create searcher with passed filters", "errors", errorUnkownScope, "user", ctx.User.ID)
-		render.BadRequest(w, r, errorUnkownScope)
+		handlers.BadRequest(w, r, errorUnkownScope)
 		return
 	}
 	delete(args.Filters, "scope")
@@ -69,7 +70,7 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request, ctx Context) {
 	hits, err := searcher.Search(args)
 	if err != nil {
 		h.Logger.Errorw("dataset search: could not execute search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -83,7 +84,7 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request, ctx Context) {
 		globalHits, globalHitsErr := globalSearch(searcher)
 		if globalHitsErr != nil {
 			h.Logger.Errorw("publication search: could not execute global search", "errors", globalHitsErr, "user", ctx.User.ID)
-			render.InternalServerError(w, r, globalHitsErr)
+			handlers.InternalServerError(w, r, globalHitsErr)
 			return
 		}
 		isFirstUse = globalHits.Total == 0
@@ -120,7 +121,7 @@ func globalSearch(searcher backends.DatasetSearchService) (*models.DatasetHits, 
 
 func (h *Handler) CurationSearch(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -130,7 +131,7 @@ func (h *Handler) CurationSearch(w http.ResponseWriter, r *http.Request, ctx Con
 	hits, err := searcher.Search(ctx.SearchArgs)
 	if err != nil {
 		h.Logger.Errorw("dataset search: could not execute search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -144,7 +145,7 @@ func (h *Handler) CurationSearch(w http.ResponseWriter, r *http.Request, ctx Con
 		globalHits, globalHitsErr := globalSearch(searcher)
 		if globalHitsErr != nil {
 			h.Logger.Errorw("publication search: could not execute global search", "errors", globalHitsErr, "user", ctx.User.ID)
-			render.InternalServerError(w, r, globalHitsErr)
+			handlers.InternalServerError(w, r, globalHitsErr)
 			return
 		}
 		isFirstUse = globalHits.Total == 0

--- a/internal/app/handlers/datasetviewing/handler.go
+++ b/internal/app/handlers/datasetviewing/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -24,23 +23,23 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
 		d, err := h.Repository.GetDataset(bind.PathValues(r).Get("id"))
 		if err != nil {
 			if err == backends.ErrNotFound {
-				render.NotFound(w, r, err)
+				handlers.NotFound(w, r, ctx, err)
 			} else {
-				render.InternalServerError(w, r, err)
+				handlers.InternalServerError(w, r, err)
 			}
 			return
 		}
 
 		if !ctx.User.CanViewDataset(d) {
 			h.Logger.Warn("view dataset: user isn't allowed to view the dataset:", "error", err, "dataset", d.ID, "user", ctx.User.ID)
-			render.Forbidden(w, r)
+			handlers.Forbidden(w, r)
 			return
 		}
 

--- a/internal/app/handlers/datasetviewing/show.go
+++ b/internal/app/handlers/datasetviewing/show.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/ugent-library/biblio-backend/internal/app/displays"
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/models"
 	"github.com/ugent-library/biblio-backend/internal/render"
 	"github.com/ugent-library/biblio-backend/internal/render/display"
@@ -84,7 +85,7 @@ func (h *Handler) ShowPublications(w http.ResponseWriter, r *http.Request, ctx C
 	relatedPublications, err := h.Repository.GetVisibleDatasetPublications(ctx.User, ctx.Dataset)
 	if err != nil {
 		h.Logger.Errorw("show dataset publications: could not get publications", "errors", err, "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/errors.go
+++ b/internal/app/handlers/errors.go
@@ -1,10 +1,22 @@
-package render
+package handlers
 
 import (
 	"net/http"
+
+	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 var AuthURL string
+
+type Context struct {
+	BaseContext
+}
+
+type YieldNotFound struct {
+	Context
+	PageTitle string
+	ActiveNav string
+}
 
 // TODO Make these user friendly pages with a nice error message informing the user on
 //    a. What went wrong
@@ -16,8 +28,14 @@ func InternalServerError(w http.ResponseWriter, r *http.Request, err error) {
 }
 
 // HTTP 404 error
-func NotFound(w http.ResponseWriter, r *http.Request, err error) {
-	http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+func NotFound(w http.ResponseWriter, r *http.Request, ctx BaseContext, err error) {
+	// http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	render.NotFoundLayout(w, "layouts/default", "pages/notfound", YieldNotFound{
+		Context: Context{
+			BaseContext: ctx,
+		},
+		PageTitle: "Biblio",
+	})
 }
 
 // HTTP 400 error

--- a/internal/app/handlers/frontoffice/errors.go
+++ b/internal/app/handlers/frontoffice/errors.go
@@ -1,0 +1,41 @@
+package frontoffice
+
+import (
+	"net/http"
+)
+
+var AuthURL string
+
+// TODO Make these user friendly pages with a nice error message informing the user on
+//    a. What went wrong
+//    b. How to proceed
+
+// HTTP 500 error
+func InternalServerError(w http.ResponseWriter, r *http.Request, err error) {
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}
+
+// HTTP 404 error
+func NotFound(w http.ResponseWriter, r *http.Request, err error) {
+	http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+}
+
+// HTTP 400 error
+func BadRequest(w http.ResponseWriter, r *http.Request, err error) {
+	http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+}
+
+// HTTP 401 error, redirects the user to the authentication url
+func Unauthorized(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("HX-Request") != "" {
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+
+	http.Redirect(w, r, AuthURL, http.StatusTemporaryRedirect)
+}
+
+// HTTP 403 error
+func Forbidden(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+}

--- a/internal/app/handlers/frontoffice/handler.go
+++ b/internal/app/handlers/frontoffice/handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends/filestore"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 	"github.com/ugent-library/biblio-backend/internal/validation"
 )
 
@@ -751,15 +750,15 @@ func (h *Handler) GetPublication(w http.ResponseWriter, r *http.Request) {
 	p, err := h.Repository.GetPublication(bind.PathValues(r).Get("id"))
 	if err != nil {
 		if err == backends.ErrNotFound {
-			render.NotFound(w, r, err)
+			NotFound(w, r, err)
 		} else {
-			render.InternalServerError(w, r, err)
+			InternalServerError(w, r, err)
 		}
 		return
 	}
 	j, err := json.Marshal(h.mapPublication(p))
 	if err != nil {
-		render.InternalServerError(w, r, err)
+		InternalServerError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -770,15 +769,15 @@ func (h *Handler) GetDataset(w http.ResponseWriter, r *http.Request) {
 	p, err := h.Repository.GetDataset(bind.PathValues(r).Get("id"))
 	if err != nil {
 		if err == backends.ErrNotFound {
-			render.NotFound(w, r, err)
+			NotFound(w, r, err)
 		} else {
-			render.InternalServerError(w, r, err)
+			InternalServerError(w, r, err)
 		}
 		return
 	}
 	j, err := json.Marshal(h.mapDataset(p))
 	if err != nil {
-		render.InternalServerError(w, r, err)
+		InternalServerError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -794,7 +793,7 @@ type BindGetAll struct {
 func (h *Handler) GetAllPublications(w http.ResponseWriter, r *http.Request) {
 	b := BindGetAll{}
 	if err := bind.RequestQuery(r, &b); err != nil {
-		render.BadRequest(w, r, err)
+		BadRequest(w, r, err)
 		return
 	}
 
@@ -811,7 +810,7 @@ func (h *Handler) GetAllPublications(w http.ResponseWriter, r *http.Request) {
 	log.Printf("%d, %d", args.Limit(), args.Offset())
 	hits, err := h.PublicationSearchService.Search(args)
 	if err != nil {
-		render.InternalServerError(w, r, err)
+		InternalServerError(w, r, err)
 		return
 	}
 	mappedHits := &Hits{
@@ -825,7 +824,7 @@ func (h *Handler) GetAllPublications(w http.ResponseWriter, r *http.Request) {
 	}
 	j, err := json.Marshal(mappedHits)
 	if err != nil {
-		render.InternalServerError(w, r, err)
+		InternalServerError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -835,7 +834,7 @@ func (h *Handler) GetAllPublications(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) GetAllDatasets(w http.ResponseWriter, r *http.Request) {
 	b := BindGetAll{}
 	if err := bind.RequestQuery(r, &b); err != nil {
-		render.BadRequest(w, r, err)
+		BadRequest(w, r, err)
 		return
 	}
 
@@ -851,7 +850,7 @@ func (h *Handler) GetAllDatasets(w http.ResponseWriter, r *http.Request) {
 	}
 	hits, err := h.DatasetSearchService.Search(args)
 	if err != nil {
-		render.InternalServerError(w, r, err)
+		InternalServerError(w, r, err)
 		return
 	}
 	mappedHits := &Hits{
@@ -865,7 +864,7 @@ func (h *Handler) GetAllDatasets(w http.ResponseWriter, r *http.Request) {
 	}
 	j, err := json.Marshal(mappedHits)
 	if err != nil {
-		render.InternalServerError(w, r, err)
+		InternalServerError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -878,15 +877,15 @@ func (h *Handler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 	p, err := h.Repository.GetPublication(vals.Get("id"))
 	if err != nil {
 		if err == backends.ErrNotFound {
-			render.NotFound(w, r, err)
+			NotFound(w, r, err)
 		} else {
-			render.InternalServerError(w, r, err)
+			InternalServerError(w, r, err)
 		}
 		return
 	}
 
 	if p.Status != "public" {
-		render.Forbidden(w, r)
+		Forbidden(w, r)
 		return
 	}
 
@@ -909,11 +908,11 @@ func (h *Handler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 		ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 		if !h.IPFilter.Allowed(ip) {
 			log.Printf("ip %s not allowed, allowed: %s", ip, viper.GetString("ip-ranges"))
-			render.Forbidden(w, r)
+			Forbidden(w, r)
 			return
 		}
 	default:
-		render.Forbidden(w, r)
+		Forbidden(w, r)
 		return
 	}
 

--- a/internal/app/handlers/impersonating/handler.go
+++ b/internal/app/handlers/impersonating/handler.go
@@ -24,7 +24,7 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
@@ -58,12 +58,12 @@ type YieldAddImpersonationSuggest struct {
 func (h *Handler) AddImpersonation(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if ctx.OriginalUser != nil {
 		h.Logger.Warn("add impersonation: already impersonating", "user", ctx.OriginalUser.ID)
-		render.BadRequest(w, r, errors.New("already impersonating"))
+		handlers.BadRequest(w, r, errors.New("already impersonating"))
 	}
 
 	if !ctx.User.CanImpersonateUser() {
 		h.Logger.Warn("add impersonation: user does not have permission to impersonate", "user", ctx.User.ID)
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
@@ -76,26 +76,26 @@ func (h *Handler) AddImpersonation(w http.ResponseWriter, r *http.Request, ctx C
 func (h *Handler) AddImpersonationSuggest(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if ctx.OriginalUser != nil {
 		h.Logger.Warn("add impersonation: already impersonating", "user", ctx.OriginalUser.ID)
-		render.BadRequest(w, r, errors.New("already impersonating"))
+		handlers.BadRequest(w, r, errors.New("already impersonating"))
 	}
 
 	if !ctx.User.CanImpersonateUser() {
 		h.Logger.Warn("add impersonation: user does not have permission to impersonate", "user", ctx.User.ID)
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
 	b := BindAddCImpersonationSuggest{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("suggest impersonation: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	hits, err := h.UserSearchService.SuggestUsers(b.FirstName + " " + b.LastName)
 	if err != nil {
 		h.Logger.Errorw("suggest impersonation: could not suggest users:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -122,25 +122,25 @@ func (h *Handler) AddImpersonationSuggest(w http.ResponseWriter, r *http.Request
 func (h *Handler) CreateImpersonation(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if ctx.OriginalUser != nil {
 		h.Logger.Warn("create impersonation: already impersonating", "user", ctx.OriginalUser.ID)
-		render.BadRequest(w, r, errors.New("already impersonating"))
+		handlers.BadRequest(w, r, errors.New("already impersonating"))
 	}
 
 	if !ctx.User.CanImpersonateUser() {
 		h.Logger.Warn("create impersonation: user does not have permission to impersonate", "user", ctx.User.ID)
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
 	b := BindCreateImpersonation{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("create impersonation: could not bind request arguments", "errors", err, "request", r)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	user, err := h.UserService.GetUser(b.ID)
 	if err != nil {
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -149,7 +149,7 @@ func (h *Handler) CreateImpersonation(w http.ResponseWriter, r *http.Request, ct
 	session, err := h.SessionStore.Get(r, h.SessionName)
 	if err != nil {
 		h.Logger.Errorw("create impersonation: session could not be retrieved:", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -160,7 +160,7 @@ func (h *Handler) CreateImpersonation(w http.ResponseWriter, r *http.Request, ct
 
 	if err = session.Save(r, w); err != nil {
 		h.Logger.Errorw("create impersonation: session could not be saved:", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -169,13 +169,13 @@ func (h *Handler) CreateImpersonation(w http.ResponseWriter, r *http.Request, ct
 
 func (h *Handler) DeleteImpersonation(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if ctx.OriginalUser == nil {
-		render.BadRequest(w, r, errors.New("no impersonation"))
+		handlers.BadRequest(w, r, errors.New("no impersonation"))
 	}
 
 	session, err := h.SessionStore.Get(r, h.SessionName)
 	if err != nil {
 		h.Logger.Errorw("delete impersonation: session could not be retrieved:", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -186,7 +186,7 @@ func (h *Handler) DeleteImpersonation(w http.ResponseWriter, r *http.Request, ct
 
 	if err = session.Save(r, w); err != nil {
 		h.Logger.Errorw("delete impersonation: session could not be saved:", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/mediatypes/handler.go
+++ b/internal/app/handlers/mediatypes/handler.go
@@ -22,7 +22,7 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
 			h.Logger.Warnw("mediatypes: user is not authorized to access this resource:", "user", ctx.User.ID)
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
@@ -49,7 +49,7 @@ func (h *Handler) Suggest(w http.ResponseWriter, r *http.Request, ctx Context) {
 	hits, err := h.MediaTypeSearchService.SuggestMediaTypes(q)
 	if err != nil {
 		h.Logger.Errorw("suggest mediatype: could not suggest mediatypes:", "errors", err, "query", q, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/notfound/handler.go
+++ b/internal/app/handlers/notfound/handler.go
@@ -30,7 +30,7 @@ type YieldNotFound struct {
 }
 
 func (h *Handler) NotFound(w http.ResponseWriter, r *http.Request, ctx Context) {
-	render.Layout(w, "layouts/default", "pages/notfound", YieldNotFound{
+	render.NotFoundLayout(w, "layouts/default", "pages/notfound", YieldNotFound{
 		Context:   ctx,
 		PageTitle: "Biblio",
 	})

--- a/internal/app/handlers/orcid/handler.go
+++ b/internal/app/handlers/orcid/handler.go
@@ -36,7 +36,7 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
 			h.Logger.Warnw("orcid: user is not authorized to access this resource", "user", ctx.User.ID)
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
@@ -66,19 +66,19 @@ func (h *Handler) Add(w http.ResponseWriter, r *http.Request, ctx Context) {
 	b := BindAdd{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("add orcid: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	p, err := h.Repository.GetPublication(b.PublicationID)
 	if err != nil {
 		h.Logger.Errorw("add orcid: could not get publication", "errors", err, "publication", b.PublicationID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 	if !ctx.User.CanViewPublication(p) {
 		h.Logger.Warnw("add orcid: user has no permission to view this publication", "publication", b.PublicationID, "user", ctx.User.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -117,7 +117,7 @@ func (h *Handler) AddAll(w http.ResponseWriter, r *http.Request, ctx Context) {
 	)
 	if err != nil {
 		h.Logger.Errorw("add all orcid: could not add all publications to the users orcid", "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationcreating/handler.go
+++ b/internal/app/handlers/publicationcreating/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -26,7 +25,7 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
@@ -37,13 +36,13 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 		if id := bind.PathValues(r).Get("id"); id != "" {
 			d, err := h.Repository.GetPublication(id)
 			if err != nil {
-				render.NotFound(w, r, err)
+				handlers.NotFound(w, r, ctx, err)
 				return
 			}
 
 			if !ctx.User.CanEditPublication(d) {
 				h.Logger.Warn("create publication: user isn't allowed to edit the publication:", "errors", err, "publication", id, "user", ctx.User.ID)
-				render.Forbidden(w, r)
+				handlers.Forbidden(w, r)
 				return
 			}
 

--- a/internal/app/handlers/publicationcreating/import.go
+++ b/internal/app/handlers/publicationcreating/import.go
@@ -102,7 +102,7 @@ func (h *Handler) AddSingleImportConfirm(w http.ResponseWriter, r *http.Request,
 	b := BindImportSingle{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("import confirm single publication: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -114,7 +114,7 @@ func (h *Handler) AddSingleImportConfirm(w http.ResponseWriter, r *http.Request,
 
 		if err != nil {
 			h.Logger.Warnw("import single publication: could not execute search for duplicates", "errors", err, "args", args, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 
@@ -140,7 +140,7 @@ func (h *Handler) AddSingleImport(w http.ResponseWriter, r *http.Request, ctx Co
 	b := BindImportSingle{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("import single publication: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -210,7 +210,7 @@ func (h *Handler) AddSingleImport(w http.ResponseWriter, r *http.Request, ctx Co
 
 	if err != nil {
 		h.Logger.Errorf("import single publication: -could not save the publication:", "error", err, "identifier", b.Identifier, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -262,7 +262,7 @@ func (h *Handler) AddSingleConfirm(w http.ResponseWriter, r *http.Request, ctx C
 func (h *Handler) AddSinglePublish(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanEditPublication(ctx.Publication) {
 		h.Logger.Warnw("add single publication publish: user has no permission to publish publication.", "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -292,7 +292,7 @@ func (h *Handler) AddSinglePublish(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("add single publication publish: could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -328,7 +328,7 @@ func (h *Handler) AddMultipleImport(w http.ResponseWriter, r *http.Request, ctx 
 	file, _, err := r.FormFile("file")
 	if err != nil {
 		h.Logger.Warnw("add multiple import publication: could not retrieve file from request", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 	defer file.Close()
@@ -410,7 +410,7 @@ func (h *Handler) AddMultipleConfirm(w http.ResponseWriter, r *http.Request, ctx
 	searchArgs := models.NewSearchArgs()
 	if err := bind.RequestQuery(r, searchArgs); err != nil {
 		h.Logger.Warnw("add multiple confirm publication: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -426,7 +426,7 @@ func (h *Handler) AddMultipleConfirm(w http.ResponseWriter, r *http.Request, ctx
 
 	if err != nil {
 		h.Logger.Errorw("add multiple confirm publication: could not execute search", "errors", err, "batch", batchID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -465,7 +465,7 @@ func (h *Handler) AddMultiplePublish(w http.ResponseWriter, r *http.Request, ctx
 
 	if err != nil {
 		h.Logger.Errorw("add multiple publish publication: could not publish publications", "errors", err, "batch", batchID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -478,7 +478,7 @@ func (h *Handler) AddMultipleFinish(w http.ResponseWriter, r *http.Request, ctx 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.RequestQuery(r, searchArgs); err != nil {
 		h.Logger.Warnw("add multiple finish publication: could not bind request arguments", "errors", err, "request", r)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -494,7 +494,7 @@ func (h *Handler) AddMultipleFinish(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorw("add multiple finish publication: could not execute search", "errors", err, "batch", batchID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/abstract.go
+++ b/internal/app/handlers/publicationediting/abstract.go
@@ -58,7 +58,7 @@ func (h *Handler) CreateAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("create publication abstract: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -91,7 +91,7 @@ func (h *Handler) CreateAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 
 	if err != nil {
 		h.Logger.Errorf("create publication abstract: could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -104,7 +104,7 @@ func (h *Handler) EditAbstract(w http.ResponseWriter, r *http.Request, ctx Conte
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("edit publication abstract: could not bind request arguments", "error", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -129,7 +129,7 @@ func (h *Handler) UpdateAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 	b := BindAbstract{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("update publication abstract: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -179,7 +179,7 @@ func (h *Handler) UpdateAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 
 	if err != nil {
 		h.Logger.Errorf("update publication abstract: could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -192,7 +192,7 @@ func (h *Handler) ConfirmDeleteAbstract(w http.ResponseWriter, r *http.Request, 
 	var b BindDeleteAbstract
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete publication abstract: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -213,7 +213,7 @@ func (h *Handler) DeleteAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 	var b BindDeleteAbstract
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete publication abstract: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -231,7 +231,7 @@ func (h *Handler) DeleteAbstract(w http.ResponseWriter, r *http.Request, ctx Con
 
 	if err != nil {
 		h.Logger.Errorf("create publication abstract: could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/activity.go
+++ b/internal/app/handlers/publicationediting/activity.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/app/localize"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/locale"
@@ -56,7 +57,7 @@ func (h *Handler) UpdateMessage(w http.ResponseWriter, r *http.Request, ctx Cont
 	b := BindMessage{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update publication reviewer note: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -87,7 +88,7 @@ func (h *Handler) UpdateMessage(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorf("update publication message: could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -96,7 +97,7 @@ func (h *Handler) UpdateMessage(w http.ResponseWriter, r *http.Request, ctx Cont
 
 func (h *Handler) EditReviewerTags(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
@@ -109,14 +110,14 @@ func (h *Handler) EditReviewerTags(w http.ResponseWriter, r *http.Request, ctx C
 
 func (h *Handler) UpdateReviewerTags(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
 	b := BindReviewerTags{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update publication reviewer tags: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -147,7 +148,7 @@ func (h *Handler) UpdateReviewerTags(w http.ResponseWriter, r *http.Request, ctx
 
 	if err != nil {
 		h.Logger.Errorf("update publication reviewer tags: could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -156,7 +157,7 @@ func (h *Handler) UpdateReviewerTags(w http.ResponseWriter, r *http.Request, ctx
 
 func (h *Handler) EditReviewerNote(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
@@ -169,14 +170,14 @@ func (h *Handler) EditReviewerNote(w http.ResponseWriter, r *http.Request, ctx C
 
 func (h *Handler) UpdateReviewerNote(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Unauthorized(w, r)
+		handlers.Unauthorized(w, r)
 		return
 	}
 
 	b := BindReviewerNote{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update publication reviewer note: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -207,7 +208,7 @@ func (h *Handler) UpdateReviewerNote(w http.ResponseWriter, r *http.Request, ctx
 
 	if err != nil {
 		h.Logger.Errorf("update publication reviewer note: could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/additional_info.go
+++ b/internal/app/handlers/publicationediting/additional_info.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ugent-library/biblio-backend/internal/app/displays"
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/app/localize"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/locale"
@@ -46,7 +47,7 @@ func (h *Handler) UpdateAdditionalInfo(w http.ResponseWriter, r *http.Request, c
 	b := BindAdditionalInfo{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update publication additional info: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -79,7 +80,7 @@ func (h *Handler) UpdateAdditionalInfo(w http.ResponseWriter, r *http.Request, c
 
 	if err != nil {
 		h.Logger.Errorf("update publication additional info: could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/conference.go
+++ b/internal/app/handlers/publicationediting/conference.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ugent-library/biblio-backend/internal/app/displays"
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/app/localize"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/locale"
@@ -47,7 +48,7 @@ func (h *Handler) UpdateConference(w http.ResponseWriter, r *http.Request, ctx C
 	b := BindConference{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update publication conference: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -82,7 +83,7 @@ func (h *Handler) UpdateConference(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("update publication conference: could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/contributors.go
+++ b/internal/app/handlers/publicationediting/contributors.go
@@ -157,7 +157,7 @@ func (h *Handler) AddContributor(w http.ResponseWriter, r *http.Request, ctx Con
 	b := BindAddContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("add publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -170,7 +170,7 @@ func (h *Handler) AddContributor(w http.ResponseWriter, r *http.Request, ctx Con
 		hits, err = h.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
 			h.Logger.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 	}
@@ -195,7 +195,7 @@ func (h *Handler) AddContributorSuggest(w http.ResponseWriter, r *http.Request, 
 	b := BindAddContributorSuggest{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("suggest publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -208,7 +208,7 @@ func (h *Handler) AddContributorSuggest(w http.ResponseWriter, r *http.Request, 
 		hits, err = h.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
 			h.Logger.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 	}
@@ -230,7 +230,7 @@ func (h *Handler) ConfirmCreateContributor(w http.ResponseWriter, r *http.Reques
 	b := BindConfirmCreateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("confirm create publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -239,7 +239,7 @@ func (h *Handler) ConfirmCreateContributor(w http.ResponseWriter, r *http.Reques
 	if b.ID != "" {
 		newC, newP, err := h.generateContributorFromPersonId(b.ID)
 		if err != nil {
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		c = newC
@@ -262,7 +262,7 @@ func (h *Handler) CreateContributor(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindCreateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("create publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -271,7 +271,7 @@ func (h *Handler) CreateContributor(w http.ResponseWriter, r *http.Request, ctx 
 	if b.ID != "" {
 		newC, newP, err := h.generateContributorFromPersonId(b.ID)
 		if err != nil {
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		c = newC
@@ -308,7 +308,7 @@ func (h *Handler) CreateContributor(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorf("create publication contributor: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -337,14 +337,14 @@ func (h *Handler) EditContributor(w http.ResponseWriter, r *http.Request, ctx Co
 	b := BindEditContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("edit publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	c, err := ctx.Publication.GetContributor(b.Role, b.Position)
 	if err != nil {
 		h.Logger.Errorw("edit publication contributor: could not get the contributor", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -352,7 +352,7 @@ func (h *Handler) EditContributor(w http.ResponseWriter, r *http.Request, ctx Co
 	if c.ID != "" {
 		p, err := h.PersonService.GetPerson(c.ID)
 		if err != nil {
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		active = p.Active
@@ -368,7 +368,7 @@ func (h *Handler) EditContributor(w http.ResponseWriter, r *http.Request, ctx Co
 	hits, err := h.PersonSearchService.SuggestPeople(firstName + " " + lastName)
 	if err != nil {
 		h.Logger.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -405,14 +405,14 @@ func (h *Handler) EditContributorSuggest(w http.ResponseWriter, r *http.Request,
 	b := BindEditContributorSuggest{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("suggest publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	c, err := ctx.Publication.GetContributor(b.Role, b.Position)
 	if err != nil {
 		h.Logger.Errorw("edit publication contributor: could not get the contributor", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -422,7 +422,7 @@ func (h *Handler) EditContributorSuggest(w http.ResponseWriter, r *http.Request,
 		hits, err = h.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
 			h.Logger.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 
@@ -452,14 +452,14 @@ func (h *Handler) ConfirmUpdateContributor(w http.ResponseWriter, r *http.Reques
 	b := BindConfirmUpdateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("confirm update publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	oldC, err := ctx.Publication.GetContributor(b.Role, b.Position)
 	if err != nil {
 		h.Logger.Errorw("edit publication contributor: could not get the contributor", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -468,7 +468,7 @@ func (h *Handler) ConfirmUpdateContributor(w http.ResponseWriter, r *http.Reques
 	if b.ID != "" {
 		newC, newP, err := h.generateContributorFromPersonId(b.ID)
 		if err != nil {
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		c = newC
@@ -495,7 +495,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindUpdateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -505,7 +505,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 		newC, newP, err := h.generateContributorFromPersonId(b.ID)
 		if err != nil {
 			h.Logger.Errorw("update publication contributor: could not fetch person", "errors", err, "personid", b.ID, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 		c = newC
@@ -518,7 +518,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err := ctx.Publication.SetContributor(b.Role, b.Position, c); err != nil {
 		h.Logger.Errorw("update publication contributor: could not set the contributor", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -548,7 +548,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorf("update publication contributor: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -558,7 +558,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 		hits, err := h.PersonSearchService.SuggestPeople(nextC.FirstName + " " + nextC.LastName)
 		if err != nil {
 			h.Logger.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", ctx.User.ID)
-			render.InternalServerError(w, r, err)
+			handlers.InternalServerError(w, r, err)
 			return
 		}
 
@@ -568,7 +568,7 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 		if nextC.ID != "" {
 			p, err := h.PersonService.GetPerson(nextC.ID)
 			if err != nil {
-				render.InternalServerError(w, r, err)
+				handlers.InternalServerError(w, r, err)
 				return
 			}
 			nextActive = p.Active
@@ -599,7 +599,7 @@ func (h *Handler) ConfirmDeleteContributor(w http.ResponseWriter, r *http.Reques
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -614,13 +614,13 @@ func (h *Handler) DeleteContributor(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete publication contributor: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	if err := ctx.Publication.RemoveContributor(b.Role, b.Position); err != nil {
 		h.Logger.Warnw("delete publication contributor: could not remove contributor", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -649,7 +649,7 @@ func (h *Handler) DeleteContributor(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorf("delete publication contributor: Could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -663,7 +663,7 @@ func (h *Handler) OrderContributors(w http.ResponseWriter, r *http.Request, ctx 
 	b := BindOrderContributors{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("order publication contributors: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -671,7 +671,7 @@ func (h *Handler) OrderContributors(w http.ResponseWriter, r *http.Request, ctx 
 	if len(b.Positions) != len(contributors) {
 		err := fmt.Errorf("positions don't match number of contributors")
 		h.Logger.Warnw("order publication contributors: could not order contributors", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 	newContributors := make([]*models.Contributor, len(contributors))
@@ -692,7 +692,7 @@ func (h *Handler) OrderContributors(w http.ResponseWriter, r *http.Request, ctx 
 
 	if err != nil {
 		h.Logger.Errorf("order publication contributors: Could not save the publication:", "errors", err, "identifier", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/dataset.go
+++ b/internal/app/handlers/publicationediting/dataset.go
@@ -37,7 +37,7 @@ func (h *Handler) AddDataset(w http.ResponseWriter, r *http.Request, ctx Context
 	hits, err := h.searchRelatedDatasets(ctx.User, ctx.Publication, "")
 	if err != nil {
 		h.Logger.Errorw("add dataset publication: could not execute search", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -51,14 +51,14 @@ func (h *Handler) SuggestDatasets(w http.ResponseWriter, r *http.Request, ctx Co
 	b := BindSuggestDatasets{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("suggest publication datasets: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	hits, err := h.searchRelatedDatasets(ctx.User, ctx.Publication, b.Query)
 	if err != nil {
 		h.Logger.Errorw("add dataset publication: could not execute search", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -72,7 +72,7 @@ func (h *Handler) CreateDataset(w http.ResponseWriter, r *http.Request, ctx Cont
 	b := BindDataset{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("create publication dataset: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -80,7 +80,7 @@ func (h *Handler) CreateDataset(w http.ResponseWriter, r *http.Request, ctx Cont
 	d, err := h.Repository.GetDataset(b.DatasetID)
 	if err != nil {
 		h.Logger.Errorw("create dataset publication: could not get dataset", "errors", err, "publication", ctx.Publication.ID, "dataset", b.DatasetID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -90,7 +90,7 @@ func (h *Handler) CreateDataset(w http.ResponseWriter, r *http.Request, ctx Cont
 	err = h.Repository.AddPublicationDataset(ctx.Publication, d, ctx.User)
 	if err != nil {
 		h.Logger.Errorw("create publication dataset: could not add dataset to publication", "errors", err, "publication", ctx.Publication.ID, "dataset", b.DatasetID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -98,14 +98,14 @@ func (h *Handler) CreateDataset(w http.ResponseWriter, r *http.Request, ctx Cont
 	ctx.Publication, err = h.Repository.GetPublication(ctx.Publication.ID)
 	if err != nil {
 		h.Logger.Errorw("create dataset publication: could not get publication", "errors", err, "publication", ctx.Publication.ID, "dataset", b.DatasetID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
 	relatedDatasets, err := h.Repository.GetVisiblePublicationDatasets(ctx.User, ctx.Publication)
 	if err != nil {
 		h.Logger.Errorw("create dataset publication: could not get related datasets", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -119,7 +119,7 @@ func (h *Handler) ConfirmDeleteDataset(w http.ResponseWriter, r *http.Request, c
 	b := BindDeleteDataset{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete publication dataset: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -140,7 +140,7 @@ func (h *Handler) DeleteDataset(w http.ResponseWriter, r *http.Request, ctx Cont
 	b := BindDeleteDataset{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete publication dataset: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -155,7 +155,7 @@ func (h *Handler) DeleteDataset(w http.ResponseWriter, r *http.Request, ctx Cont
 	d, err := h.Repository.GetDataset(b.DatasetID)
 	if err != nil {
 		h.Logger.Errorw("delete dataset publication: could not get dataset", "errors", err, "publication", ctx.Publication.ID, "dataset", b.DatasetID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -166,7 +166,7 @@ func (h *Handler) DeleteDataset(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorw("delete dataset publication: could not remove dataset", "errors", err, "publication", ctx.Publication.ID, "dataset", b.DatasetID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -174,14 +174,14 @@ func (h *Handler) DeleteDataset(w http.ResponseWriter, r *http.Request, ctx Cont
 	ctx.Publication, err = h.Repository.GetPublication(ctx.Publication.ID)
 	if err != nil {
 		h.Logger.Errorw("delete dataset publication: could not get publication", "errors", err, "publication", ctx.Publication.ID, "dataset", b.DatasetID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
 	relatedDatasets, err := h.Repository.GetVisiblePublicationDatasets(ctx.User, ctx.Publication)
 	if err != nil {
 		h.Logger.Errorw("create dataset publication: could not get related datasets", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/delete.go
+++ b/internal/app/handlers/publicationediting/delete.go
@@ -30,7 +30,7 @@ func (h *Handler) ConfirmDelete(w http.ResponseWriter, r *http.Request, ctx Cont
 func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanDeletePublication(ctx.Publication) {
 		h.Logger.Warnw("delete publication: user is unauthorized", "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -49,7 +49,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request, ctx Context) {
 
 	if err != nil {
 		h.Logger.Errorf("delete publication: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/department.go
+++ b/internal/app/handlers/publicationediting/department.go
@@ -42,7 +42,7 @@ func (h *Handler) AddDepartment(w http.ResponseWriter, r *http.Request, ctx Cont
 	hits, err := h.OrganizationSearchService.SuggestOrganizations("")
 	if err != nil {
 		h.Logger.Errorw("add publication department: could not suggest organization", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -56,14 +56,14 @@ func (h *Handler) SuggestDepartments(w http.ResponseWriter, r *http.Request, ctx
 	b := BindSuggestDepartments{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("suggest publication departments could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	hits, err := h.OrganizationSearchService.SuggestOrganizations(b.Query)
 	if err != nil {
 		h.Logger.Errorw("add publication department: could not suggest organization", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -77,14 +77,14 @@ func (h *Handler) CreateDepartment(w http.ResponseWriter, r *http.Request, ctx C
 	b := BindDepartment{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("create publication department: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	org, err := h.OrganizationService.GetOrganization(b.DepartmentID)
 	if err != nil {
 		h.Logger.Errorw("create publication department: could not find organization", "errors", err, "request", r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -108,7 +108,7 @@ func (h *Handler) CreateDepartment(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("create publication department: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -121,7 +121,7 @@ func (h *Handler) ConfirmDeleteDepartment(w http.ResponseWriter, r *http.Request
 	b := BindDeleteDepartment{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete publication department: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -142,7 +142,7 @@ func (h *Handler) DeleteDepartment(w http.ResponseWriter, r *http.Request, ctx C
 	var b BindDeleteDepartment
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete publication department: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -162,7 +162,7 @@ func (h *Handler) DeleteDepartment(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("delete publication department: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/details.go
+++ b/internal/app/handlers/publicationediting/details.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ugent-library/biblio-backend/internal/app/displays"
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/render"
 	"github.com/ugent-library/biblio-backend/internal/render/display"
@@ -81,7 +82,7 @@ func (h *Handler) UpdateDetails(w http.ResponseWriter, r *http.Request, ctx Cont
 	var b BindDetails
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update publication details: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -156,7 +157,7 @@ func (h *Handler) UpdateDetails(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorf("update publication details: Could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/files.go
+++ b/internal/app/handlers/publicationediting/files.go
@@ -152,7 +152,7 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request, ctx Context
 func (h *Handler) EditFile(w http.ResponseWriter, r *http.Request, ctx Context) {
 	var b BindFile
 	if err := bind.Request(r, &b); err != nil {
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -179,7 +179,7 @@ func (h *Handler) RefreshEditFileForm(w http.ResponseWriter, r *http.Request, ct
 	var b BindFile
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("edit publication file license: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -237,7 +237,7 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request, ctx Context
 	b := BindFile{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("update publication file: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -300,7 +300,7 @@ func (h *Handler) UpdateFile(w http.ResponseWriter, r *http.Request, ctx Context
 
 	if err != nil {
 		h.Logger.Errorf("update publication file: could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -313,7 +313,7 @@ func (h *Handler) ConfirmDeleteFile(w http.ResponseWriter, r *http.Request, ctx 
 	var b BindDeleteFile
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete publication file: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -336,7 +336,7 @@ func (h *Handler) DeleteFile(w http.ResponseWriter, r *http.Request, ctx Context
 	var b BindDeleteFile
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete publication file: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -354,7 +354,7 @@ func (h *Handler) DeleteFile(w http.ResponseWriter, r *http.Request, ctx Context
 
 	if err != nil {
 		h.Logger.Errorf("delete publication file: could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/handler.go
+++ b/internal/app/handlers/publicationediting/handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends/filestore"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -32,7 +31,7 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
@@ -41,7 +40,7 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 		if err != nil {
 			if err == backends.ErrNotFound {
 				h.Logger.Warn("edit publication: could not find publication with id:", "errors", err, "id", id, "user", ctx.User.ID)
-				render.NotFound(w, r, err)
+				handlers.NotFound(w, r, ctx, err)
 			} else {
 				h.Logger.Error(
 					"edit publication: unexpected error when retrieving publication with id:",
@@ -49,14 +48,14 @@ func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) htt
 					"id", id,
 					"user", ctx.User.ID,
 				)
-				render.InternalServerError(w, r, err)
+				handlers.InternalServerError(w, r, err)
 			}
 			return
 		}
 
 		if !ctx.User.CanEditPublication(pub) {
 			h.Logger.Warn("edit publication: user isn't allowed to edit the publication:", "errors", err, "publication", id, "user", ctx.User.ID)
-			render.Forbidden(w, r)
+			handlers.Forbidden(w, r)
 			return
 		}
 

--- a/internal/app/handlers/publicationediting/lay_summary.go
+++ b/internal/app/handlers/publicationediting/lay_summary.go
@@ -58,7 +58,7 @@ func (h *Handler) CreateLaySummary(w http.ResponseWriter, r *http.Request, ctx C
 	var b BindLaySummary
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("create publication lay summary: could not bind request arguments", "error", err, "request", r)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -93,7 +93,7 @@ func (h *Handler) CreateLaySummary(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("create publication lay summary: Could not save the publication:", "error", err, "identifier", ctx.Publication.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -106,7 +106,7 @@ func (h *Handler) EditLaySummary(w http.ResponseWriter, r *http.Request, ctx Con
 	var b BindLaySummary
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("edit publication lay summary: could not bind request arguments", "error", err, "request", r)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -132,7 +132,7 @@ func (h *Handler) UpdateLaySummary(w http.ResponseWriter, r *http.Request, ctx C
 	b := BindLaySummary{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("update publication lay summary: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -182,7 +182,7 @@ func (h *Handler) UpdateLaySummary(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("update publication lay summary: Could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -195,7 +195,7 @@ func (h *Handler) ConfirmDeleteLaySummary(w http.ResponseWriter, r *http.Request
 	var b BindDeleteLaySummary
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete publication lay summary: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -216,7 +216,7 @@ func (h *Handler) DeleteLaySummary(w http.ResponseWriter, r *http.Request, ctx C
 	var b BindDeleteLaySummary
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete publication lay summary: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -234,7 +234,7 @@ func (h *Handler) DeleteLaySummary(w http.ResponseWriter, r *http.Request, ctx C
 
 	if err != nil {
 		h.Logger.Errorf("delete publication lay summary: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/link.go
+++ b/internal/app/handlers/publicationediting/link.go
@@ -59,7 +59,7 @@ func (h *Handler) CreateLink(w http.ResponseWriter, r *http.Request, ctx Context
 	b := BindLink{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("add publication link: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -93,7 +93,7 @@ func (h *Handler) CreateLink(w http.ResponseWriter, r *http.Request, ctx Context
 
 	if err != nil {
 		h.Logger.Errorf("add publication link: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -106,7 +106,7 @@ func (h *Handler) EditLink(w http.ResponseWriter, r *http.Request, ctx Context) 
 	b := BindLink{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("edit publication link: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -114,7 +114,7 @@ func (h *Handler) EditLink(w http.ResponseWriter, r *http.Request, ctx Context) 
 	link := ctx.Publication.GetLink(b.LinkID)
 	if link == nil {
 		h.Logger.Warnw("edit publication link: could not get link", "link", b.LinkID, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.BadRequest(
+		handlers.BadRequest(
 			w,
 			r,
 			fmt.Errorf("no link found for %s in publication %s", b.LinkID, ctx.Publication.ID),
@@ -134,7 +134,7 @@ func (h *Handler) UpdateLink(w http.ResponseWriter, r *http.Request, ctx Context
 	b := BindLink{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
 		h.Logger.Warnw("update publication link: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -178,7 +178,7 @@ func (h *Handler) UpdateLink(w http.ResponseWriter, r *http.Request, ctx Context
 
 	if err != nil {
 		h.Logger.Errorf("update publication link: Could not save the publication:", "errors", err, "identifier", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -191,7 +191,7 @@ func (h *Handler) ConfirmDeleteLink(w http.ResponseWriter, r *http.Request, ctx 
 	var b BindDeleteLink
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Errorw("confirm delete publication link: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -213,7 +213,7 @@ func (h *Handler) DeleteLink(w http.ResponseWriter, r *http.Request, ctx Context
 	var b BindDeleteLink
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete publication link: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -231,7 +231,7 @@ func (h *Handler) DeleteLink(w http.ResponseWriter, r *http.Request, ctx Context
 
 	if err != nil {
 		h.Logger.Errorf("delete publication link: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/lock.go
+++ b/internal/app/handlers/publicationediting/lock.go
@@ -22,7 +22,7 @@ type YieldLock struct {
 func (h *Handler) Lock(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
 		h.Logger.Warnw("lock publication: user has no permission to lock", "user", ctx.User.ID, "publication", ctx.Publication.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -52,7 +52,7 @@ func (h *Handler) Lock(w http.ResponseWriter, r *http.Request, ctx Context) {
 
 	if err != nil {
 		h.Logger.Errorf("lock publication: could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -68,7 +68,7 @@ func (h *Handler) Lock(w http.ResponseWriter, r *http.Request, ctx Context) {
 func (h *Handler) Unlock(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
 		h.Logger.Warnw("unlock publication: user has no permission to lock", "user", ctx.User.ID, "publication", ctx.Publication.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -99,7 +99,7 @@ func (h *Handler) Unlock(w http.ResponseWriter, r *http.Request, ctx Context) {
 
 	if err != nil {
 		h.Logger.Errorf("unlock publication: could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/project.go
+++ b/internal/app/handlers/publicationediting/project.go
@@ -38,7 +38,7 @@ func (h *Handler) AddProject(w http.ResponseWriter, r *http.Request, ctx Context
 	hits, err := h.ProjectSearchService.SuggestProjects("")
 	if err != nil {
 		h.Logger.Errorw("add publication project: could not suggest projects:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -52,14 +52,14 @@ func (h *Handler) SuggestProjects(w http.ResponseWriter, r *http.Request, ctx Co
 	b := BindSuggestProjects{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("suggest publication project: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	hits, err := h.ProjectSearchService.SuggestProjects(b.Query)
 	if err != nil {
 		h.Logger.Errorw("suggest publication project: could not suggest projects:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -73,14 +73,14 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request, ctx Cont
 	b := BindProject{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("create publication project: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
 	project, err := h.ProjectService.GetProject(b.ProjectID)
 	if err != nil {
 		h.Logger.Errorw("create publication project: could not get project:", "errors", err, "publication", ctx.Publication.ID, "project", b.ProjectID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 	ctx.Publication.AddProject(&models.PublicationProject{
@@ -102,7 +102,7 @@ func (h *Handler) CreateProject(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorf("create publication project: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (h *Handler) ConfirmDeleteProject(w http.ResponseWriter, r *http.Request, c
 	b := BindDeleteProject{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("confirm delete publication project: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -136,7 +136,7 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request, ctx Cont
 	var b BindDeleteProject
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("delete publication project: could not bind request arguments:", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -156,7 +156,7 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	if err != nil {
 		h.Logger.Errorf("delete publication project: Could not save the publication:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/publish.go
+++ b/internal/app/handlers/publicationediting/publish.go
@@ -30,7 +30,7 @@ func (h *Handler) ConfirmPublish(w http.ResponseWriter, r *http.Request, ctx Con
 func (h *Handler) Publish(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanEditPublication(ctx.Publication) {
 		h.Logger.Warnw("publish dataset: user has no permission to publish", "user", ctx.User.ID, "publication", ctx.Publication.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -65,7 +65,7 @@ func (h *Handler) Publish(w http.ResponseWriter, r *http.Request, ctx Context) {
 
 	if err != nil {
 		h.Logger.Errorf("publish dataset: could not save the dataset:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/republish.go
+++ b/internal/app/handlers/publicationediting/republish.go
@@ -30,7 +30,7 @@ func (h *Handler) ConfirmRepublish(w http.ResponseWriter, r *http.Request, ctx C
 func (h *Handler) Republish(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanEditPublication(ctx.Publication) {
 		h.Logger.Warnw("republish publication: user has no permission to republish", "user", ctx.User.ID, "publication", ctx.Publication.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -65,7 +65,7 @@ func (h *Handler) Republish(w http.ResponseWriter, r *http.Request, ctx Context)
 
 	if err != nil {
 		h.Logger.Errorf("republish publication: could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/type.go
+++ b/internal/app/handlers/publicationediting/type.go
@@ -32,7 +32,7 @@ func (h *Handler) UpdateType(w http.ResponseWriter, r *http.Request, ctx Context
 	b := BindType{}
 	if err := bind.RequestForm(r, &b); err != nil {
 		h.Logger.Warnw("update publication type: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 
@@ -65,7 +65,7 @@ func (h *Handler) UpdateType(w http.ResponseWriter, r *http.Request, ctx Context
 
 	if err != nil {
 		h.Logger.Errorf("update publication type: Could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationediting/withdraw.go
+++ b/internal/app/handlers/publicationediting/withdraw.go
@@ -29,7 +29,7 @@ func (h *Handler) ConfirmWithdraw(w http.ResponseWriter, r *http.Request, ctx Co
 func (h *Handler) Withdraw(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanEditPublication(ctx.Publication) {
 		h.Logger.Warnw("witdraw publication: user has no permission to withdraw", "user", ctx.User.ID, "publication", ctx.Publication.ID)
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -60,7 +60,7 @@ func (h *Handler) Withdraw(w http.ResponseWriter, r *http.Request, ctx Context) 
 
 	if err != nil {
 		h.Logger.Errorf("withdraw publication: could not save the publication:", "error", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/publicationexporting/export.go
+++ b/internal/app/handlers/publicationexporting/export.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 func (h *Handler) ExportByCurationSearch(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -23,7 +23,7 @@ func (h *Handler) ExportByCurationSearch(w http.ResponseWriter, r *http.Request,
 			"errors", e,
 			"user", ctx.User.ID,
 		)
-		render.InternalServerError(w, r, e)
+		handlers.InternalServerError(w, r, e)
 		return
 	}
 	exporter := exporterFactory(w)
@@ -39,7 +39,7 @@ func (h *Handler) ExportByCurationSearch(w http.ResponseWriter, r *http.Request,
 			"errors", searcherErr,
 			"user", ctx.User.ID,
 		)
-		render.InternalServerError(w, r, fmt.Errorf("unable to execute search"))
+		handlers.InternalServerError(w, r, fmt.Errorf("unable to execute search"))
 		return
 	}
 
@@ -60,7 +60,7 @@ func (h *Handler) ExportByCurationSearch(w http.ResponseWriter, r *http.Request,
 
 	if err := exporter.Flush(); err != nil {
 		h.Logger.Errorw("publication search: could not export search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 }

--- a/internal/app/handlers/publicationexporting/handler.go
+++ b/internal/app/handlers/publicationexporting/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -29,21 +28,21 @@ type ExportArgs struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
 		searchArgs := models.NewSearchArgs()
 		if err := bind.Request(r, searchArgs); err != nil {
 			h.Logger.Warnw("publication search: could not bind search arguments", "errors", err, "request", r, "user", ctx.User.ID)
-			render.BadRequest(w, r, err)
+			handlers.BadRequest(w, r, err)
 			return
 		}
 
 		exportArgs := &ExportArgs{}
 		if err := bind.Request(r, exportArgs); err != nil {
 			h.Logger.Warnw("publication search: could not bind export arguments", "errors", err, "request", r, "user", ctx.User.ID)
-			render.BadRequest(w, r, err)
+			handlers.BadRequest(w, r, err)
 			return
 		}
 		if exportArgs.Format == "" {

--- a/internal/app/handlers/publicationsearching/handler.go
+++ b/internal/app/handlers/publicationsearching/handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends/filestore"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -25,14 +24,14 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
 		searchArgs := models.NewSearchArgs()
 		if err := bind.Request(r, searchArgs); err != nil {
 			h.Logger.Warnw("publication search: could not bind search arguments", "errors", err, "request", r, "user", ctx.User.ID)
-			render.BadRequest(w, r, err)
+			handlers.BadRequest(w, r, err)
 			return
 		}
 		searchArgs.Cleanup()

--- a/internal/app/handlers/publicationsearching/search.go
+++ b/internal/app/handlers/publicationsearching/search.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/backends"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
@@ -62,7 +63,7 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request, ctx Context) {
 	default:
 		errorUnkownScope := fmt.Errorf("unknown scope: %s", args.FilterFor("scope"))
 		h.Logger.Warnw("publication search: could not create searcher with passed filters", "errors", errorUnkownScope, "user", ctx.User.ID)
-		render.BadRequest(w, r, errorUnkownScope)
+		handlers.BadRequest(w, r, errorUnkownScope)
 		return
 	}
 	delete(args.Filters, "scope")
@@ -70,7 +71,7 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request, ctx Context) {
 	hits, err := searcher.Search(args)
 	if err != nil {
 		h.Logger.Errorw("publication search: could not execute search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -84,7 +85,7 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request, ctx Context) {
 		globalHits, globalHitsErr := globalSearch(searcher)
 		if globalHitsErr != nil {
 			h.Logger.Errorw("publication search: could not execute global search", "errors", globalHitsErr, "user", ctx.User.ID)
-			render.InternalServerError(w, r, globalHitsErr)
+			handlers.InternalServerError(w, r, globalHitsErr)
 			return
 		}
 		isFirstUse = globalHits.Total == 0
@@ -121,7 +122,7 @@ func globalSearch(searcher backends.PublicationSearchService) (*models.Publicati
 
 func (h *Handler) CurationSearch(w http.ResponseWriter, r *http.Request, ctx Context) {
 	if !ctx.User.CanCurate() {
-		render.Forbidden(w, r)
+		handlers.Forbidden(w, r)
 		return
 	}
 
@@ -131,7 +132,7 @@ func (h *Handler) CurationSearch(w http.ResponseWriter, r *http.Request, ctx Con
 	hits, err := searcher.Search(ctx.SearchArgs)
 	if err != nil {
 		h.Logger.Errorw("publication search: could not execute search", "errors", err, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 
@@ -145,7 +146,7 @@ func (h *Handler) CurationSearch(w http.ResponseWriter, r *http.Request, ctx Con
 		globalHits, globalHitsErr := globalSearch(searcher)
 		if globalHitsErr != nil {
 			h.Logger.Errorw("curation publication search: could not execute global search", "errors", globalHitsErr, "user", ctx.User.ID)
-			render.InternalServerError(w, r, globalHitsErr)
+			handlers.InternalServerError(w, r, globalHitsErr)
 			return
 		}
 		isFirstUse = globalHits.Total == 0

--- a/internal/app/handlers/publicationviewing/handler.go
+++ b/internal/app/handlers/publicationviewing/handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/backends/filestore"
 	"github.com/ugent-library/biblio-backend/internal/bind"
 	"github.com/ugent-library/biblio-backend/internal/models"
-	"github.com/ugent-library/biblio-backend/internal/render"
 )
 
 type Handler struct {
@@ -26,23 +25,23 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
 		p, err := h.Repository.GetPublication(bind.PathValues(r).Get("id"))
 		if err != nil {
 			if err == backends.ErrNotFound {
-				render.NotFound(w, r, err)
+				handlers.NotFound(w, r, ctx, err)
 			} else {
-				render.InternalServerError(w, r, err)
+				handlers.InternalServerError(w, r, err)
 			}
 			return
 		}
 
 		if !ctx.User.CanViewPublication(p) {
 			h.Logger.Warn("publication viewing: user isn't allowed to ivew the publication:", "errors", err, "publication", p.ID, "user", ctx.User.ID)
-			render.Forbidden(w, r)
+			handlers.Forbidden(w, r)
 			return
 		}
 

--- a/internal/app/handlers/publicationviewing/show.go
+++ b/internal/app/handlers/publicationviewing/show.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/ugent-library/biblio-backend/internal/app/displays"
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/models"
 	"github.com/ugent-library/biblio-backend/internal/render"
 	"github.com/ugent-library/biblio-backend/internal/render/display"
@@ -100,7 +101,7 @@ func (h *Handler) ShowDatasets(w http.ResponseWriter, r *http.Request, ctx Conte
 	relatedDatasets, err := h.Repository.GetVisiblePublicationDatasets(ctx.User, ctx.Publication)
 	if err != nil {
 		h.Logger.Warn("show publication datasets: could not get publication datasets:", "errors", err, "publication", ctx.Publication.ID, "user", ctx.User.ID)
-		render.InternalServerError(w, r, err)
+		handlers.InternalServerError(w, r, err)
 		return
 	}
 

--- a/internal/app/handlers/tasks/handler.go
+++ b/internal/app/handlers/tasks/handler.go
@@ -23,7 +23,7 @@ type Context struct {
 func (h *Handler) Wrap(fn func(http.ResponseWriter, *http.Request, Context)) http.HandlerFunc {
 	return h.BaseHandler.Wrap(func(w http.ResponseWriter, r *http.Request, ctx handlers.BaseContext) {
 		if ctx.User == nil {
-			render.Unauthorized(w, r)
+			handlers.Unauthorized(w, r)
 			return
 		}
 
@@ -47,7 +47,7 @@ func (h *Handler) Status(w http.ResponseWriter, r *http.Request, ctx Context) {
 	b := BindStatus{}
 	if err := bind.Request(r, &b); err != nil {
 		h.Logger.Warnw("tasks: could not bind request arguments", "errors", err, "request", r, "user", ctx.User.ID)
-		render.BadRequest(w, r, err)
+		handlers.BadRequest(w, r, err)
 		return
 	}
 

--- a/internal/commands/server.go
+++ b/internal/commands/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/ugent-library/biblio-backend/internal/app/handlers"
 	"github.com/ugent-library/biblio-backend/internal/app/helpers"
 	"github.com/ugent-library/biblio-backend/internal/app/routes"
 	"github.com/ugent-library/biblio-backend/internal/backends"
@@ -266,7 +267,7 @@ func buildRouter(services *backends.Services, logger *zap.SugaredLogger) *mux.Ro
 	}
 
 	// init render
-	render.AuthURL = baseURL.Path + "/login"
+	handlers.AuthURL = baseURL.Path + "/login"
 
 	for _, funcs := range funcMaps {
 		render.Funcs(funcs)

--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -243,7 +243,7 @@ func (r *Renderer) ExecuteView(w io.Writer, view string, data any) error {
 	return nil
 }
 
-func (r *Renderer) Layout(w http.ResponseWriter, partial, view string, data any) {
+func (r *Renderer) Layout(w http.ResponseWriter, s int, partial, view string, data any) {
 	b := r.bufPool.Get().(*bytes.Buffer)
 	defer func() {
 		b.Reset()
@@ -256,9 +256,30 @@ func (r *Renderer) Layout(w http.ResponseWriter, partial, view string, data any)
 		return
 	}
 
+	w.WriteHeader(s)
+
 	r.SetContentType(w)
 	io.Copy(w, b)
 }
+
+// func (r *Renderer) NotFoundLayout(w http.ResponseWriter, partial, view string, data any) {
+// 	b := r.bufPool.Get().(*bytes.Buffer)
+// 	defer func() {
+// 		b.Reset()
+// 		r.bufPool.Put(b)
+// 	}()
+
+// 	if err := r.ExecuteLayout(b, partial, view, data); err != nil {
+// 		log.Println(err)
+// 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+// 		return
+// 	}
+
+// 	w.WriteHeader(http.StatusNotFound)
+
+// 	r.SetContentType(w)
+// 	io.Copy(w, b)
+// }
 
 func (r *Renderer) ExecuteLayout(w io.Writer, layout, view string, data any) error {
 	tmpl, ok := r.viewTemplates[view]
@@ -338,7 +359,11 @@ func ExecuteView(w io.Writer, view string, data any) error {
 }
 
 func Layout(w http.ResponseWriter, partial, view string, data any) {
-	defaultRenderer.Layout(w, partial, view, data)
+	defaultRenderer.Layout(w, http.StatusOK, partial, view, data)
+}
+
+func NotFoundLayout(w http.ResponseWriter, partial, view string, data any) {
+	defaultRenderer.Layout(w, http.StatusNotFound, partial, view, data)
 }
 
 func ExecuteLayout(w io.Writer, partial, view string, data any) error {


### PR DESCRIPTION
Quite a lot of changes at this stage. So, need a quick review. It works, but is it architecturally sound?

I'm mainly moving `render.Errors` to `handlers.Errors` which seems about right. The rendering package is about, well, rendering data in HTML; whereas this pertains to handling requests / responses.

Moreover, I had to differentiate and also create an `frontoffice.Errors` package which feels like the idiomatic way of doing things since the `frontoffice` package serves as an JSON API.

Finally, I also had some trouble with the authenticating `Callback` handler. This one doesn't have a fully populated `Context` object, since the OIDC flow is still not completed. So,there's still some work here.