### PR TITLE
simply es6 calls

### DIFF
--- a/internal/backends/es6/client.go
+++ b/internal/backends/es6/client.go
@@ -1,10 +1,15 @@
 package es6
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/elastic/go-elasticsearch/v6"
+	"github.com/elastic/go-elasticsearch/v6/esapi"
+	"github.com/pkg/errors"
 	// "github.com/elastic/go-elasticsearch/v6/esutil"
 )
 
@@ -49,5 +54,30 @@ func (c *Client) DeleteIndex() error {
 	if res.IsError() {
 		return fmt.Errorf("error: %s", res)
 	}
+	return nil
+}
+
+func (c *Client) searchWithOpts(opts []func(*esapi.SearchRequest), responseBody any) error {
+
+	res, err := c.es.Search(opts...)
+
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+
+	if res.IsError() {
+		buf := &bytes.Buffer{}
+		if _, err := io.Copy(buf, res.Body); err != nil {
+			return err
+		}
+		return errors.New("Es6 error response: " + buf.String())
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(responseBody); err != nil {
+		return errors.Wrap(err, "Error parsing the response body")
+	}
+
 	return nil
 }

--- a/internal/backends/es6/dataset_searcher.go
+++ b/internal/backends/es6/dataset_searcher.go
@@ -133,9 +133,10 @@ func (searcher *DatasetSearcher) buildEsOpts(query M) ([]func(*esapi.SearchReque
 }
 
 func (searcher *DatasetSearcher) esSearch(opts ...func(*esapi.SearchRequest)) (*models.DatasetHits, error) {
-	res, err := searcher.Client.es.Search(opts...)
+	var envelop datasetResEnvelope
+	err := searcher.Client.searchWithOpts(opts, &envelop)
 	if err != nil {
 		return nil, err
 	}
-	return decodeDatasetRes(res, []string{})
+	return decodeDatasetRes(&envelop, []string{})
 }

--- a/internal/backends/es6/publication.go
+++ b/internal/backends/es6/publication.go
@@ -143,13 +143,14 @@ func (publications *Publications) Search(args *models.SearchArgs) (*models.Publi
 	}
 	opts = append(opts, publications.Client.es.Search.WithBody(&buf))
 
-	res, err := publications.Client.es.Search(opts...)
+	var res publicationResEnvelope
+	err := publications.Client.searchWithOpts(opts, &res)
 	if err != nil {
 		return nil, err
 	}
 
 	// READ RESPONSE FROM ES
-	hits, err := decodePublicationRes(res, args.Facets)
+	hits, err := decodePublicationRes(&res, args.Facets)
 	if err != nil {
 		return nil, err
 	}
@@ -287,21 +288,7 @@ type publicationResEnvelope struct {
 	}
 }
 
-func decodePublicationRes(res *esapi.Response, facets []string) (*models.PublicationHits, error) {
-	defer res.Body.Close()
-
-	if res.IsError() {
-		buf := &bytes.Buffer{}
-		if _, err := io.Copy(buf, res.Body); err != nil {
-			return nil, err
-		}
-		return nil, errors.New("Es6 error response: " + buf.String())
-	}
-
-	var r publicationResEnvelope
-	if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-		return nil, errors.Wrap(err, "Error parsing the response body")
-	}
+func decodePublicationRes(r *publicationResEnvelope, facets []string) (*models.PublicationHits, error) {
 
 	hits := models.PublicationHits{}
 	hits.Total = r.Hits.Total

--- a/internal/backends/es6/publication_searcher.go
+++ b/internal/backends/es6/publication_searcher.go
@@ -130,9 +130,10 @@ func (searcher *PublicationSearcher) buildEsOpts(query M) ([]func(*esapi.SearchR
 }
 
 func (searcher *PublicationSearcher) esSearch(opts ...func(*esapi.SearchRequest)) (*models.PublicationHits, error) {
-	res, err := searcher.Client.es.Search(opts...)
+	var envelop publicationResEnvelope
+	err := searcher.Client.searchWithOpts(opts, &envelop)
 	if err != nil {
 		return nil, err
 	}
-	return decodePublicationRes(res, []string{})
+	return decodePublicationRes(&envelop, []string{})
 }


### PR DESCRIPTION
Done:

* Added method `searchWithOpts` to `es6.Client` that accepts list of options and the destination response body object in which to decode the response from elasticsearch (may be map or struct reference). This removes the need to read the elasticsearch body in methods decodePublicationRes and decodeDatasetRes. It returns an error, and translates any underlying elasticsearch as an error, instead of doing the same in decodePublicationRes and decodeDatasetRes
* made changes were referred to