### PR TITLE
add user to view display forms to allow for conditionals; apply for legacy; format boolean

### DIFF
--- a/internal/app/displays/book_chapter_details.go
+++ b/internal/app/displays/book_chapter_details.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func bookChapterDetails(l *locale.Locale, p *models.Publication) *display.Display {
-	return display.New().
+func bookChapterDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
+	d := display.New().
 		WithTheme("default").
 		AddSection(
 			&display.Text{
@@ -51,8 +51,9 @@ func bookChapterDetails(l *locale.Locale, p *models.Publication) *display.Displa
 				Value: l.TS("publication_publishing_statuses", p.PublicationStatus),
 			},
 			&display.Text{
-				Label: l.T("builder.extern"),
-				Value: helpers.FormatBool(p.Extern, "✓", "-"),
+				Label:         l.T("builder.extern"),
+				Value:         helpers.FormatBool(p.Extern, "true", "false"),
+				ValueTemplate: "format/boolean_string",
 			},
 			&display.Text{
 				Label:    l.T("builder.year"),
@@ -117,4 +118,14 @@ func bookChapterDetails(l *locale.Locale, p *models.Publication) *display.Displa
 				Values: p.EISBN,
 			},
 		)
+
+	if user.CanCurate() {
+		d.Sections[0].Fields = append(d.Sections[0].Fields, &display.Text{
+			Label:         l.T("builder.legacy"),
+			Value:         helpers.FormatBool(p.Legacy, "true", "false"),
+			ValueTemplate: "format/boolean_string",
+		})
+	}
+
+	return d
 }

--- a/internal/app/displays/book_details.go
+++ b/internal/app/displays/book_details.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func bookDetails(l *locale.Locale, p *models.Publication) *display.Display {
-	return display.New().
+func bookDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
+	d := display.New().
 		WithTheme("default").
 		AddSection(
 			&display.Text{
@@ -46,8 +46,9 @@ func bookDetails(l *locale.Locale, p *models.Publication) *display.Display {
 				Value: l.TS("publication_publishing_statuses", p.PublicationStatus),
 			},
 			&display.Text{
-				Label: l.T("builder.extern"),
-				Value: helpers.FormatBool(p.Extern, "✓", "-"),
+				Label:         l.T("builder.extern"),
+				Value:         helpers.FormatBool(p.Extern, "true", "false"),
+				ValueTemplate: "format/boolean_string",
 			},
 			&display.Text{
 				Label:    l.T("builder.year"),
@@ -108,4 +109,14 @@ func bookDetails(l *locale.Locale, p *models.Publication) *display.Display {
 				Values: p.EISBN,
 			},
 		)
+
+	if user.CanCurate() {
+		d.Sections[0].Fields = append(d.Sections[0].Fields, &display.Text{
+			Label:         l.T("builder.legacy"),
+			Value:         helpers.FormatBool(p.Legacy, "true", "false"),
+			ValueTemplate: "format/boolean_string",
+		})
+	}
+
+	return d
 }

--- a/internal/app/displays/conference_details.go
+++ b/internal/app/displays/conference_details.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func conferenceDetails(l *locale.Locale, p *models.Publication) *display.Display {
-	return display.New().
+func conferenceDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
+	d := display.New().
 		WithTheme("default").
 		AddSection(
 			&display.Text{
@@ -60,8 +60,9 @@ func conferenceDetails(l *locale.Locale, p *models.Publication) *display.Display
 				Value: l.TS("publication_publishing_statuses", p.PublicationStatus),
 			},
 			&display.Text{
-				Label: l.T("builder.extern"),
-				Value: helpers.FormatBool(p.Extern, "✓", "-"),
+				Label:         l.T("builder.extern"),
+				Value:         helpers.FormatBool(p.Extern, "true", "false"),
+				ValueTemplate: "format/boolean_string",
 			},
 			&display.Text{
 				Label:    l.T("builder.year"),
@@ -133,4 +134,14 @@ func conferenceDetails(l *locale.Locale, p *models.Publication) *display.Display
 				Values: p.EISBN,
 			},
 		)
+
+	if user.CanCurate() {
+		d.Sections[0].Fields = append(d.Sections[0].Fields, &display.Text{
+			Label:         l.T("builder.legacy"),
+			Value:         helpers.FormatBool(p.Legacy, "true", "false"),
+			ValueTemplate: "format/boolean_string",
+		})
+	}
+
+	return d
 }

--- a/internal/app/displays/dataset_details.go
+++ b/internal/app/displays/dataset_details.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func DatasetDetails(l *locale.Locale, d *models.Dataset) *display.Display {
+func DatasetDetails(user *models.User, l *locale.Locale, d *models.Dataset) *display.Display {
 	return display.New().
 		WithTheme("default").
 		AddSection(

--- a/internal/app/displays/dissertation_details.go
+++ b/internal/app/displays/dissertation_details.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func dissertationDetails(l *locale.Locale, p *models.Publication) *display.Display {
-	return display.New().
+func dissertationDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
+	d := display.New().
 		WithTheme("default").
 		AddSection(
 			&display.Text{
@@ -46,8 +46,9 @@ func dissertationDetails(l *locale.Locale, p *models.Publication) *display.Displ
 				Value: l.TS("publication_publishing_statuses", p.PublicationStatus),
 			},
 			&display.Text{
-				Label: l.T("builder.extern"),
-				Value: helpers.FormatBool(p.Extern, "✓", "-"),
+				Label:         l.T("builder.extern"),
+				Value:         helpers.FormatBool(p.Extern, "true", "false"),
+				ValueTemplate: "format/boolean_string",
 			},
 			&display.Text{
 				Label:    l.T("builder.year"),
@@ -139,4 +140,14 @@ func dissertationDetails(l *locale.Locale, p *models.Publication) *display.Displ
 				Values: p.EISBN,
 			},
 		)
+
+	if user.CanCurate() {
+		d.Sections[0].Fields = append(d.Sections[0].Fields, &display.Text{
+			Label:         l.T("builder.legacy"),
+			Value:         helpers.FormatBool(p.Legacy, "true", "false"),
+			ValueTemplate: "format/boolean_string",
+		})
+	}
+
+	return d
 }

--- a/internal/app/displays/editor_details.go
+++ b/internal/app/displays/editor_details.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func bookEditorDetails(l *locale.Locale, p *models.Publication) *display.Display {
-	return display.New().
+func bookEditorDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
+	d := display.New().
 		WithTheme("default").
 		AddSection(
 			&display.Text{
@@ -46,8 +46,9 @@ func bookEditorDetails(l *locale.Locale, p *models.Publication) *display.Display
 				Value: l.TS("publication_publishing_statuses", p.PublicationStatus),
 			},
 			&display.Text{
-				Label: l.T("builder.extern"),
-				Value: helpers.FormatBool(p.Extern, "✓", "-"),
+				Label:         l.T("builder.extern"),
+				Value:         helpers.FormatBool(p.Extern, "true", "false"),
+				ValueTemplate: "format/boolean_string",
 			},
 			&display.Text{
 				Label:    l.T("builder.year"),
@@ -108,4 +109,14 @@ func bookEditorDetails(l *locale.Locale, p *models.Publication) *display.Display
 				Values: p.EISBN,
 			},
 		)
+
+	if user.CanCurate() {
+		d.Sections[0].Fields = append(d.Sections[0].Fields, &display.Text{
+			Label:         l.T("builder.legacy"),
+			Value:         helpers.FormatBool(p.Legacy, "true", "false"),
+			ValueTemplate: "format/boolean_string",
+		})
+	}
+
+	return d
 }

--- a/internal/app/displays/issue_editor_details.go
+++ b/internal/app/displays/issue_editor_details.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func issueEditorDetails(l *locale.Locale, p *models.Publication) *display.Display {
-	return display.New().
+func issueEditorDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
+	d := display.New().
 		WithTheme("default").
 		AddSection(
 			&display.Text{
@@ -55,8 +55,9 @@ func issueEditorDetails(l *locale.Locale, p *models.Publication) *display.Displa
 				Value: l.TS("publication_publishing_statuses", p.PublicationStatus),
 			},
 			&display.Text{
-				Label: l.T("builder.extern"),
-				Value: helpers.FormatBool(p.Extern, "✓", "-"),
+				Label:         l.T("builder.extern"),
+				Value:         helpers.FormatBool(p.Extern, "true", "false"),
+				ValueTemplate: "format/boolean_string",
 			},
 			&display.Text{
 				Label:    l.T("builder.year"),
@@ -113,4 +114,14 @@ func issueEditorDetails(l *locale.Locale, p *models.Publication) *display.Displa
 				Values: p.EISBN,
 			},
 		)
+
+	if user.CanCurate() {
+		d.Sections[0].Fields = append(d.Sections[0].Fields, &display.Text{
+			Label:         l.T("builder.legacy"),
+			Value:         helpers.FormatBool(p.Legacy, "true", "false"),
+			ValueTemplate: "format/boolean_string",
+		})
+	}
+
+	return d
 }

--- a/internal/app/displays/journal_article_details.go
+++ b/internal/app/displays/journal_article_details.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func journalArticleDetails(l *locale.Locale, p *models.Publication) *display.Display {
-	return display.New().
+func journalArticleDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
+	d := display.New().
 		WithTheme("default").
 		AddSection(
 			&display.Text{
@@ -59,8 +59,9 @@ func journalArticleDetails(l *locale.Locale, p *models.Publication) *display.Dis
 				Value: l.TS("publication_publishing_statuses", p.PublicationStatus),
 			},
 			&display.Text{
-				Label: l.T("builder.extern"),
-				Value: helpers.FormatBool(p.Extern, "✓", "-"),
+				Label:         l.T("builder.extern"),
+				Value:         helpers.FormatBool(p.Extern, "true", "false"),
+				ValueTemplate: "format/boolean_string",
 			},
 			&display.Text{
 				Label:    l.T("builder.year"),
@@ -141,4 +142,14 @@ func journalArticleDetails(l *locale.Locale, p *models.Publication) *display.Dis
 				Value: p.ESCIID,
 			},
 		)
+
+	if user.CanCurate() {
+		d.Sections[0].Fields = append(d.Sections[0].Fields, &display.Text{
+			Label:         l.T("builder.legacy"),
+			Value:         helpers.FormatBool(p.Legacy, "true", "false"),
+			ValueTemplate: "format/boolean_string",
+		})
+	}
+
+	return d
 }

--- a/internal/app/displays/miscellaneous_details.go
+++ b/internal/app/displays/miscellaneous_details.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func miscellaneousDetails(l *locale.Locale, p *models.Publication) *display.Display {
-	return display.New().
+func miscellaneousDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
+	d := display.New().
 		WithTheme("default").
 		AddSection(
 			&display.Text{
@@ -59,8 +59,9 @@ func miscellaneousDetails(l *locale.Locale, p *models.Publication) *display.Disp
 				Value: l.TS("publication_publishing_statuses", p.PublicationStatus),
 			},
 			&display.Text{
-				Label: l.T("builder.extern"),
-				Value: helpers.FormatBool(p.Extern, "✓", "-"),
+				Label:         l.T("builder.extern"),
+				Value:         helpers.FormatBool(p.Extern, "true", "false"),
+				ValueTemplate: "format/boolean_string",
 			},
 			&display.Text{
 				Label:    l.T("builder.year"),
@@ -145,4 +146,14 @@ func miscellaneousDetails(l *locale.Locale, p *models.Publication) *display.Disp
 				Value: p.ESCIID,
 			},
 		)
+
+	if user.CanCurate() {
+		d.Sections[0].Fields = append(d.Sections[0].Fields, &display.Text{
+			Label:         l.T("builder.legacy"),
+			Value:         helpers.FormatBool(p.Legacy, "true", "false"),
+			ValueTemplate: "format/boolean_string",
+		})
+	}
+
+	return d
 }

--- a/internal/app/displays/publication_additional_info.go
+++ b/internal/app/displays/publication_additional_info.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func PublicationAdditionalInfo(l *locale.Locale, p *models.Publication) *display.Display {
+func PublicationAdditionalInfo(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
 	return display.New().
 		WithTheme("default").
 		AddSection(

--- a/internal/app/displays/publication_conference.go
+++ b/internal/app/displays/publication_conference.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func PublicationConference(l *locale.Locale, p *models.Publication) *display.Display {
+func PublicationConference(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
 	return display.New().
 		WithTheme("default").
 		AddSection(

--- a/internal/app/displays/publication_details.go
+++ b/internal/app/displays/publication_details.go
@@ -6,24 +6,24 @@ import (
 	"github.com/ugent-library/biblio-backend/internal/render/display"
 )
 
-func PublicationDetails(l *locale.Locale, p *models.Publication) *display.Display {
+func PublicationDetails(user *models.User, l *locale.Locale, p *models.Publication) *display.Display {
 	switch p.Type {
 	case "book_chapter":
-		return bookChapterDetails(l, p)
+		return bookChapterDetails(user, l, p)
 	case "book_editor":
-		return bookEditorDetails(l, p)
+		return bookEditorDetails(user, l, p)
 	case "book":
-		return bookDetails(l, p)
+		return bookDetails(user, l, p)
 	case "conference":
-		return conferenceDetails(l, p)
+		return conferenceDetails(user, l, p)
 	case "dissertation":
-		return dissertationDetails(l, p)
+		return dissertationDetails(user, l, p)
 	case "issue_editor":
-		return issueEditorDetails(l, p)
+		return issueEditorDetails(user, l, p)
 	case "journal_article":
-		return journalArticleDetails(l, p)
+		return journalArticleDetails(user, l, p)
 	case "miscellaneous":
-		return miscellaneousDetails(l, p)
+		return miscellaneousDetails(user, l, p)
 	default:
 		return display.New()
 	}

--- a/internal/app/handlers/datasetcreating/import.go
+++ b/internal/app/handlers/datasetcreating/import.go
@@ -172,7 +172,7 @@ func (h *Handler) AddImport(w http.ResponseWriter, r *http.Request, ctx Context)
 		SubNavs:        []string{"description", "contributors", "publications"},
 		ActiveSubNav:   "description",
 		Dataset:        d,
-		DisplayDetails: displays.DatasetDetails(ctx.Locale, d),
+		DisplayDetails: displays.DatasetDetails(ctx.User, ctx.Locale, d),
 	})
 }
 
@@ -185,7 +185,7 @@ func (h *Handler) AddDescription(w http.ResponseWriter, r *http.Request, ctx Con
 		SubNavs:        []string{"description", "contributors", "publications"},
 		ActiveSubNav:   "description",
 		Dataset:        ctx.Dataset,
-		DisplayDetails: displays.DatasetDetails(ctx.Locale, ctx.Dataset),
+		DisplayDetails: displays.DatasetDetails(ctx.User, ctx.Locale, ctx.Dataset),
 	})
 }
 

--- a/internal/app/handlers/datasetediting/details.go
+++ b/internal/app/handlers/datasetediting/details.go
@@ -136,7 +136,7 @@ func (h *Handler) UpdateDetails(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	render.View(w, "dataset/refresh_details", YieldDetails{
 		Context:        ctx,
-		DisplayDetails: displays.DatasetDetails(ctx.Locale, ctx.Dataset),
+		DisplayDetails: displays.DatasetDetails(ctx.User, ctx.Locale, ctx.Dataset),
 	})
 }
 

--- a/internal/app/handlers/datasetviewing/show.go
+++ b/internal/app/handlers/datasetviewing/show.go
@@ -68,7 +68,7 @@ func (h *Handler) ShowDescription(w http.ResponseWriter, r *http.Request, ctx Co
 		Context:        ctx,
 		SubNavs:        subNavs,
 		ActiveSubNav:   "description",
-		DisplayDetails: displays.DatasetDetails(ctx.Locale, ctx.Dataset),
+		DisplayDetails: displays.DatasetDetails(ctx.User, ctx.Locale, ctx.Dataset),
 	})
 }
 

--- a/internal/app/handlers/publicationcreating/import.go
+++ b/internal/app/handlers/publicationcreating/import.go
@@ -231,7 +231,7 @@ func (h *Handler) AddSingleImport(w http.ResponseWriter, r *http.Request, ctx Co
 		SubNavs:        []string{"description", "files", "contributors", "datasets"},
 		ActiveSubNav:   subNav,
 		Publication:    p,
-		DisplayDetails: displays.PublicationDetails(ctx.Locale, p),
+		DisplayDetails: displays.PublicationDetails(ctx.User, ctx.Locale, p),
 	})
 }
 
@@ -249,7 +249,7 @@ func (h *Handler) AddSingleDescription(w http.ResponseWriter, r *http.Request, c
 		SubNavs:        []string{"description", "files", "contributors", "datasets"},
 		ActiveSubNav:   subNav,
 		Publication:    ctx.Publication,
-		DisplayDetails: displays.PublicationDetails(ctx.Locale, ctx.Publication),
+		DisplayDetails: displays.PublicationDetails(ctx.User, ctx.Locale, ctx.Publication),
 	})
 }
 

--- a/internal/app/handlers/publicationediting/additional_info.go
+++ b/internal/app/handlers/publicationediting/additional_info.go
@@ -85,7 +85,7 @@ func (h *Handler) UpdateAdditionalInfo(w http.ResponseWriter, r *http.Request, c
 
 	render.View(w, "publication/refresh_additional_info", YieldAdditionalInfo{
 		Context:               ctx,
-		DisplayAdditionalInfo: displays.PublicationAdditionalInfo(ctx.Locale, p),
+		DisplayAdditionalInfo: displays.PublicationAdditionalInfo(ctx.User, ctx.Locale, p),
 	})
 }
 

--- a/internal/app/handlers/publicationediting/conference.go
+++ b/internal/app/handlers/publicationediting/conference.go
@@ -88,7 +88,7 @@ func (h *Handler) UpdateConference(w http.ResponseWriter, r *http.Request, ctx C
 
 	render.View(w, "publication/refresh_conference", YieldConference{
 		Context:           ctx,
-		DisplayConference: displays.PublicationConference(ctx.Locale, p),
+		DisplayConference: displays.PublicationConference(ctx.User, ctx.Locale, p),
 	})
 }
 

--- a/internal/app/handlers/publicationediting/details.go
+++ b/internal/app/handlers/publicationediting/details.go
@@ -162,6 +162,6 @@ func (h *Handler) UpdateDetails(w http.ResponseWriter, r *http.Request, ctx Cont
 
 	render.View(w, "publication/refresh_details", YieldDetails{
 		Context:        ctx,
-		DisplayDetails: displays.PublicationDetails(ctx.Locale, ctx.Publication),
+		DisplayDetails: displays.PublicationDetails(ctx.User, ctx.Locale, ctx.Publication),
 	})
 }

--- a/internal/app/handlers/publicationviewing/show.go
+++ b/internal/app/handlers/publicationviewing/show.go
@@ -74,9 +74,9 @@ func (h *Handler) ShowDescription(w http.ResponseWriter, r *http.Request, ctx Co
 		Context:               ctx,
 		SubNavs:               subNavs,
 		ActiveSubNav:          "description",
-		DisplayDetails:        displays.PublicationDetails(ctx.Locale, ctx.Publication),
-		DisplayConference:     displays.PublicationConference(ctx.Locale, ctx.Publication),
-		DisplayAdditionalInfo: displays.PublicationAdditionalInfo(ctx.Locale, ctx.Publication),
+		DisplayDetails:        displays.PublicationDetails(ctx.User, ctx.Locale, ctx.Publication),
+		DisplayConference:     displays.PublicationConference(ctx.User, ctx.Locale, ctx.Publication),
+		DisplayAdditionalInfo: displays.PublicationAdditionalInfo(ctx.User, ctx.Locale, ctx.Publication),
 	})
 }
 

--- a/views/format/boolean_string.gohtml
+++ b/views/format/boolean_string.gohtml
@@ -1,5 +1,5 @@
 {{if eq . "true"}}
 <i class="if if-check-circle-fill"></i>
 {{else}}
-<i class="if if-close-circle-fill"></i>
+-
 {{end}}

--- a/views/format/boolean_string.gohtml
+++ b/views/format/boolean_string.gohtml
@@ -1,0 +1,5 @@
+{{if eq . "true"}}
+<i class="if if-check-circle-fill"></i>
+{{else}}
+<i class="if if-close-circle-fill"></i>
+{{end}}


### PR DESCRIPTION
fixes #948 

done:

* in order to allow for conditionals in the display fields, I had to add the User to every display form (also where it was not used), just like it is done for edit forms.
* show field "legacy" in the display field, when the user is a curator
* use icon circle to display boolean values
* change display field "extern" to use these icons too