### PR TITLE
Fix front office and oai licenses to make sure GISMO and FRIS receive the correct information

### DIFF
--- a/internal/app/handlers/frontoffice/handler.go
+++ b/internal/app/handlers/frontoffice/handler.go
@@ -37,8 +37,8 @@ var licenses = map[string]string{
 	"CC-BY-NC-ND-4.0":  "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License (CC BY-NC-ND 4.0)",
 	"InCopyright":      "No license (in copyright)",
 	"LicenseNotListed": "A specific license has been chosen by the rights holder. Get in touch with the rights holder for reuse rights.",
-	"CopyrightUnknown": "I don't know the status of the copyright of this publication",
-	"":                 "Get in touch with the rights holder for reuse rights.",
+	"CopyrightUnknown": "Information pending",
+	"":                 "No license (in copyright)",
 }
 
 var openLicenses = map[string]struct{}{
@@ -52,7 +52,7 @@ var openLicenses = map[string]struct{}{
 }
 
 var hiddenLicenses = map[string]struct{}{
-	"LicenseNotListed": {},
+	"InCopyright": {},
 	"CopyrightUnknown": {},
 }
 


### PR DESCRIPTION
Two changes happened for issue #975:

- Made sure that what appears in biblio front-office aligns with what people expect to read (not always what the researcher selects)
This is based on the assumption that what appears in the front-office and oai mods is the same -> apparently what appears in the front-office is also what appears in https://biblio.ugent.be/oai ([example](https://biblio.ugent.be/oai?verb=GetRecord&identifier=8694914&metadataPrefix=mods_36))

- Made sure "LicenseNotListed" (other license) records are no longer ignored for datasets. The only things that should be ignored for datasets are "CopyrightUnknown" and "InCopyright". This could also be related to the fact that [some records are not included in FRIS](https://github.com/ugent-library/biblio-backoffice/issues/966#issuecomment-1380316554)

Question: are there any other workflows besides GISMO and FRIS enting on this part of our code? Am I missing something important?

Documentation for our licenses: https://booktower.gitbook.io/product-docs/producten-en-diensten/biblio-academische-bibliografie-en-repository/licenties-en