### PR TITLE
frontoffice handler for dataset: affiliation tree incorrectly adds dep.ID twice (so always in front and at end)

### DIFF
--- a/internal/app/handlers/frontoffice/handler.go
+++ b/internal/app/handlers/frontoffice/handler.go
@@ -743,11 +743,10 @@ func (h *Handler) mapDataset(d *models.Dataset) *Publication {
 	}
 
 	for _, v := range d.Department {
-		aff := Affiliation{UGentID: v.ID}
-		for i := len(v.Tree) - 1; i >= 0; i-- {
-			aff.Path = append(aff.Path, AffiliationPath{UGentID: v.Tree[i].ID})
+		aff := Affiliation{UGentID: v.ID, Path: make([]AffiliationPath, len(v.Tree))}
+		for i, t := range v.Tree {
+			aff.Path[i] = AffiliationPath{UGentID: t.ID}
 		}
-		aff.Path = append(aff.Path, AffiliationPath{UGentID: v.ID})
 		pp.Affiliation = append(pp.Affiliation, aff)
 	}
 


### PR DESCRIPTION
frontoffice mapping for dataset sets affiliation tree incorrectly.
Copied right code from publication to dataset.

Example: https://backoffice.biblio.ugent.be/frontoffice/dataset/8591831 which show in affiliation tree WE11 - WE - UGent - WE11.

<img width="439" alt="Screenshot 2023-06-07 at 11 58 05" src="https://github.com/ugent-library/biblio-backoffice/assets/494636/1dda5133-8e67-47e4-bcac-a8a01e7a9ce5">
