### PR TITLE
Feature/improve toasters

### DIFF
--- a/assets/ugent/scss/bootstrap-additions/_toasts.scss
+++ b/assets/ugent/scss/bootstrap-additions/_toasts.scss
@@ -2,6 +2,7 @@
   position: relative;
   flex-basis: 0;
   width: 400px;
+  z-index: 9999;
 
   .close {
     position: absolute;

--- a/internal/app/handlers/datasetediting/lock.go
+++ b/internal/app/handlers/datasetediting/lock.go
@@ -64,7 +64,7 @@ func (h *Handler) Lock(w http.ResponseWriter, r *http.Request, ctx Context) {
 	}
 
 	flash := flash.SimpleFlash().
-		WithLevel("error").
+		WithLevel("success").
 		WithBody(template.HTML("<p>Dataset was successfully locked.</p>"))
 
 	h.AddSessionFlash(r, w, *flash)
@@ -118,7 +118,7 @@ func (h *Handler) Unlock(w http.ResponseWriter, r *http.Request, ctx Context) {
 	}
 
 	flash := flash.SimpleFlash().
-		WithLevel("error").
+		WithLevel("success").
 		WithBody(template.HTML("<p>Dataset was successfully unlocked.</p>"))
 
 	h.AddSessionFlash(r, w, *flash)

--- a/internal/app/handlers/publicationediting/lock.go
+++ b/internal/app/handlers/publicationediting/lock.go
@@ -64,7 +64,7 @@ func (h *Handler) Lock(w http.ResponseWriter, r *http.Request, ctx Context) {
 	}
 
 	flash := flash.SimpleFlash().
-		WithLevel("error").
+		WithLevel("success").
 		WithBody(template.HTML("<p>Publication was successfully locked.</p>"))
 
 	h.AddSessionFlash(r, w, *flash)
@@ -118,7 +118,7 @@ func (h *Handler) Unlock(w http.ResponseWriter, r *http.Request, ctx Context) {
 	}
 
 	flash := flash.SimpleFlash().
-		WithLevel("error").
+		WithLevel("success").
 		WithBody(template.HTML("<p>Publication was successfully unlocked.</p>"))
 
 	h.AddSessionFlash(r, w, *flash)

--- a/internal/app/handlers/publicationediting/publish.go
+++ b/internal/app/handlers/publicationediting/publish.go
@@ -70,7 +70,7 @@ func (h *Handler) Publish(w http.ResponseWriter, r *http.Request, ctx Context) {
 	}
 
 	flash := flash.SimpleFlash().
-		WithLevel("error").
+		WithLevel("success").
 		WithBody(template.HTML("<p>Publication was successfully published.</p>"))
 
 	h.AddSessionFlash(r, w, *flash)

--- a/internal/app/handlers/publicationediting/republish.go
+++ b/internal/app/handlers/publicationediting/republish.go
@@ -70,7 +70,7 @@ func (h *Handler) Republish(w http.ResponseWriter, r *http.Request, ctx Context)
 	}
 
 	flash := flash.SimpleFlash().
-		WithLevel("error").
+		WithLevel("success").
 		WithBody(template.HTML("<p>Publication was successfully republished.</p>"))
 
 	h.AddSessionFlash(r, w, *flash)

--- a/internal/app/handlers/publicationediting/withdraw.go
+++ b/internal/app/handlers/publicationediting/withdraw.go
@@ -65,7 +65,7 @@ func (h *Handler) Withdraw(w http.ResponseWriter, r *http.Request, ctx Context) 
 	}
 
 	flash := flash.SimpleFlash().
-		WithLevel("error").
+		WithLevel("success").
 		WithBody(template.HTML("<p>Publication was successfully witdrawn.</p>"))
 
 	h.AddSessionFlash(r, w, *flash)


### PR DESCRIPTION
Z-index is adapted in line with the prototype (only once line of css was adapted). Fixes #1119 
Success messages now look like a success message.

To figure out if we can adapt icons as well.