### PR TITLE
use pubmed search arg resulType=core and use richer attributes

### DIFF
--- a/internal/backends/pubmed/client.go
+++ b/internal/backends/pubmed/client.go
@@ -102,13 +102,13 @@ func (c *Client) GetPublication(id string) (*models.Publication, error) {
 	}
 	if authorList := attrs.Get("authorList.author"); authorList.IsArray() {
 		for _, author := range authorList.Array() {
-			var firstName string
-			var lastName string
-			if fn := author.Get("firstName"); fn.Exists() {
-				firstName = fn.String()
+			firstName := author.Get("firstName").String()
+			if firstName == "" {
+				firstName = "[missing]"
 			}
-			if ln := author.Get("lastName"); ln.Exists() {
-				lastName = ln.String()
+			lastName := author.Get("lastName").String()
+			if lastName == "" {
+				lastName = "[missing]"
 			}
 			c := models.ContributorFromFirstLastName(firstName, lastName)
 			p.Author = append(p.Author, c)

--- a/internal/backends/pubmed/client.go
+++ b/internal/backends/pubmed/client.go
@@ -14,22 +14,6 @@ import (
 )
 
 // api reference: https://europepmc.org/RestfulWebService
-/*
-	differences between resultType=lite and resultType=core
-
-	* journalTitle in lite is an abbreviation (e.g. "Plant Physiol" instead of "Plant physiology"),
-	  which equals the core attribute journalInfo.journal.medlineAbbreviation.
-	  Better to use core attribute journalInfo.journal.title.
-
-	* journalISSN in lite is a colon separated list of both ISSN and EISSN, while
-	  core attribute journalInfo.journal.issn and journalInfo.journal.essn (note the name)
-	  separates them.
-
-	* authorString in lite is a colon separated list of abbreviated full names,
-	  while core attribute authorList.author is an array of objects, containing
-	  attributes firstName, lastName, fullName (with abbreviation of firstName),
-	  and possibly also an orcid in authorId.id (if authorId.type is "ORCID")
-*/
 var reSplit = regexp.MustCompile(`\s*[,;]\s*`)
 
 type Client struct {

--- a/internal/backends/pubmed/client.go
+++ b/internal/backends/pubmed/client.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 )
 
 // api reference: https://europepmc.org/RestfulWebService
-var reSplit = regexp.MustCompile(`\s*[,;]\s*`)
 
 type Client struct {
 	url  string


### PR DESCRIPTION
Fixes #1153 , and adds other attributes from pubmed api, using the more rich api:

* add abstract. Language is always set to `eng`. ok?
* uses array `authorList.author` which holds an array of objects, instead of trying to parse `authorString`. Advantage is that `firstName` and `lastName` can now be extracted in full, while previously it showed `<first-name> <abbreviation-of-last-name`. e.g. `Gonzalez N`
* retrieve full journal title instead of abbreviation (`Plant physiology` instead of `Plant Physiol`)
* add language (different from language of abstract?)