### PR TITLE
add Constants to request context; fix issue 1152

### DIFF
--- a/internal/app/handlers/base.go
+++ b/internal/app/handlers/base.go
@@ -38,6 +38,7 @@ type BaseHandler struct {
 	SessionStore sessions.Store
 	UserService  backends.UserService
 	Localizer    *locale.Localizer
+	Constants    map[string]string
 }
 
 // also add fields to Yield method
@@ -50,6 +51,7 @@ type BaseContext struct {
 	OriginalUser *models.User
 	CSRFToken    string
 	CSRFTag      template.HTML
+	Constants    map[string]string
 }
 
 func (c BaseContext) Yield(pairs ...any) map[string]any {
@@ -62,6 +64,7 @@ func (c BaseContext) Yield(pairs ...any) map[string]any {
 		"OriginalUser": c.OriginalUser,
 		"CSRFToken":    c.CSRFToken,
 		"CSRFTag":      c.CSRFTag,
+		"Constants":    c.Constants,
 	}
 
 	n := len(pairs)
@@ -116,6 +119,7 @@ func (h BaseHandler) NewContext(r *http.Request, w http.ResponseWriter) (BaseCon
 		OriginalUser: originalUser,
 		CSRFToken:    csrf.Token(r),
 		CSRFTag:      csrf.TemplateField(r),
+		Constants:    h.Constants,
 	}, nil
 }
 

--- a/internal/app/handlers/base.go
+++ b/internal/app/handlers/base.go
@@ -32,39 +32,39 @@ func init() {
 // TODO handlers should only have access to a url builder,
 // the session and maybe the localizer
 type BaseHandler struct {
-	Router       *mux.Router
-	Logger       *zap.SugaredLogger
-	SessionName  string
-	SessionStore sessions.Store
-	UserService  backends.UserService
-	Localizer    *locale.Localizer
-	Constants    map[string]string
+	Router          *mux.Router
+	Logger          *zap.SugaredLogger
+	SessionName     string
+	SessionStore    sessions.Store
+	UserService     backends.UserService
+	Localizer       *locale.Localizer
+	FrontendBaseUrl string
 }
 
 // also add fields to Yield method
 type BaseContext struct {
-	CurrentURL   *url.URL
-	Flash        []flash.Flash
-	Locale       *locale.Locale
-	User         *models.User
-	UserRole     string
-	OriginalUser *models.User
-	CSRFToken    string
-	CSRFTag      template.HTML
-	Constants    map[string]string
+	CurrentURL      *url.URL
+	Flash           []flash.Flash
+	Locale          *locale.Locale
+	User            *models.User
+	UserRole        string
+	OriginalUser    *models.User
+	CSRFToken       string
+	CSRFTag         template.HTML
+	FrontendBaseUrl string
 }
 
 func (c BaseContext) Yield(pairs ...any) map[string]any {
 	yield := map[string]any{
-		"CurrentURL":   c.CurrentURL,
-		"Flash":        c.Flash,
-		"Locale":       c.Locale,
-		"User":         c.User,
-		"UserRole":     c.UserRole,
-		"OriginalUser": c.OriginalUser,
-		"CSRFToken":    c.CSRFToken,
-		"CSRFTag":      c.CSRFTag,
-		"Constants":    c.Constants,
+		"CurrentURL":      c.CurrentURL,
+		"Flash":           c.Flash,
+		"Locale":          c.Locale,
+		"User":            c.User,
+		"UserRole":        c.UserRole,
+		"OriginalUser":    c.OriginalUser,
+		"CSRFToken":       c.CSRFToken,
+		"CSRFTag":         c.CSRFTag,
+		"FrontendBaseUrl": c.FrontendBaseUrl,
 	}
 
 	n := len(pairs)
@@ -111,15 +111,15 @@ func (h BaseHandler) NewContext(r *http.Request, w http.ResponseWriter) (BaseCon
 	}
 
 	return BaseContext{
-		CurrentURL:   r.URL,
-		Flash:        flash,
-		Locale:       h.Localizer.GetLocale(r.Header.Get("Accept-Language")),
-		User:         user,
-		UserRole:     h.getUserRoleFromSession(session),
-		OriginalUser: originalUser,
-		CSRFToken:    csrf.Token(r),
-		CSRFTag:      csrf.TemplateField(r),
-		Constants:    h.Constants,
+		CurrentURL:      r.URL,
+		Flash:           flash,
+		Locale:          h.Localizer.GetLocale(r.Header.Get("Accept-Language")),
+		User:            user,
+		UserRole:        h.getUserRoleFromSession(session),
+		OriginalUser:    originalUser,
+		CSRFToken:       csrf.Token(r),
+		CSRFTag:         csrf.TemplateField(r),
+		FrontendBaseUrl: h.FrontendBaseUrl,
 	}, nil
 }
 

--- a/internal/app/routes/register.go
+++ b/internal/app/routes/register.go
@@ -55,15 +55,13 @@ func Register(services *backends.Services, baseURL *url.URL, router *mux.Router,
 
 	// handlers
 	baseHandler := handlers.BaseHandler{
-		Logger:       logger,
-		Router:       router,
-		SessionStore: sessionStore,
-		SessionName:  sessionName,
-		Localizer:    localizer,
-		UserService:  services.UserService,
-		Constants: map[string]string{
-			"frontend-url": viper.GetString("frontend-url"),
-		},
+		Logger:          logger,
+		Router:          router,
+		SessionStore:    sessionStore,
+		SessionName:     sessionName,
+		Localizer:       localizer,
+		UserService:     services.UserService,
+		FrontendBaseUrl: viper.GetString("frontend-url"),
 	}
 	homeHandler := &home.Handler{
 		BaseHandler: baseHandler,

--- a/internal/app/routes/register.go
+++ b/internal/app/routes/register.go
@@ -61,6 +61,9 @@ func Register(services *backends.Services, baseURL *url.URL, router *mux.Router,
 		SessionName:  sessionName,
 		Localizer:    localizer,
 		UserService:  services.UserService,
+		Constants: map[string]string{
+			"frontend-url": viper.GetString("frontend-url"),
+		},
 	}
 	homeHandler := &home.Handler{
 		BaseHandler: baseHandler,

--- a/views/dataset/search_hit.gohtml
+++ b/views/dataset/search_hit.gohtml
@@ -17,7 +17,7 @@
                 </a>
                 <div class="dropdown-divider"></div>
                 {{if eq .Dataset.Status "public"}}
-                    <a class="dropdown-item" href="{{index .Constants "frontend-url"}}/publication/{{.Dataset.ID}}" target="_blank">
+                    <a class="dropdown-item" href="{{.FrontendBaseUrl}}/publication/{{.Dataset.ID}}" target="_blank">
                         <i class="if if-book"></i>
                         <span>Public Biblio Location</span>
                     </a>

--- a/views/dataset/search_hit.gohtml
+++ b/views/dataset/search_hit.gohtml
@@ -17,7 +17,7 @@
                 </a>
                 <div class="dropdown-divider"></div>
                 {{if eq .Dataset.Status "public"}}
-                    <a class="dropdown-item" href="https://biblio.ugent.be/publication/{{.Dataset.ID}}" target="_blank">
+                    <a class="dropdown-item" href="{{index .Constants "frontend-url"}}/publication/{{.Dataset.ID}}" target="_blank">
                         <i class="if if-book"></i>
                         <span>Public Biblio Location</span>
                     </a>

--- a/views/layouts/default.layout.gohtml
+++ b/views/layouts/default.layout.gohtml
@@ -56,7 +56,7 @@
                     <div class="bc-toolbar-item">
                         <ul class="nav nav-main">
                             <li class="nav-item">
-                                <a class="nav-link collapsed btn-sm" href="https://biblio.ugent.be/contact" target="_blank">
+                                <a class="nav-link collapsed btn-sm" href="{{index .Constants "frontend-url"}}/contact" target="_blank">
                                     <i class="if if-info-circle if--small text-muted"></i>
                                     <span class="btn-text">Help</span>
                                 </a>

--- a/views/layouts/default.layout.gohtml
+++ b/views/layouts/default.layout.gohtml
@@ -56,7 +56,7 @@
                     <div class="bc-toolbar-item">
                         <ul class="nav nav-main">
                             <li class="nav-item">
-                                <a class="nav-link collapsed btn-sm" href="{{index .Constants "frontend-url"}}/contact" target="_blank">
+                                <a class="nav-link collapsed btn-sm" href="{{.FrontendBaseUrl}}/contact" target="_blank">
                                     <i class="if if-info-circle if--small text-muted"></i>
                                     <span class="btn-text">Help</span>
                                 </a>

--- a/views/pages/home.gohtml
+++ b/views/pages/home.gohtml
@@ -83,7 +83,7 @@
                                 <p class="text-muted">Explore 200 years of publications and datasets, published by Ghent
                                 University researchers.</p>
                             </div>
-                            <a class="btn btn-outline-primary" href="https://biblio.ugent.be">
+                            <a class="btn btn-outline-primary" href="{{index .Constants "frontend-url"}}">
                                 <span class="btn-text">Go to Biblio Academic Bibliography</span>
                                 <i class="if if-external-link"></i>
                             </a>

--- a/views/pages/home.gohtml
+++ b/views/pages/home.gohtml
@@ -83,7 +83,7 @@
                                 <p class="text-muted">Explore 200 years of publications and datasets, published by Ghent
                                 University researchers.</p>
                             </div>
-                            <a class="btn btn-outline-primary" href="{{index .Constants "frontend-url"}}">
+                            <a class="btn btn-outline-primary" href="{{.FrontendBaseUrl}}">
                                 <span class="btn-text">Go to Biblio Academic Bibliography</span>
                                 <i class="if if-external-link"></i>
                             </a>

--- a/views/publication/search_hit.gohtml
+++ b/views/publication/search_hit.gohtml
@@ -23,7 +23,7 @@
                 </a>
                 <div class="dropdown-divider"></div>
                 {{if eq .Publication.Status "public"}}
-                <a class="dropdown-item" href="https://biblio.ugent.be/publication/{{.Publication.ID}}" target="_blank">
+                <a class="dropdown-item" href="{{index .Constants "frontend-url"}}/publication/{{.Publication.ID}}" target="_blank">
                     <i class="if if-book"></i>
                     <span>Public Biblio Location</span>
                 </a>

--- a/views/publication/search_hit.gohtml
+++ b/views/publication/search_hit.gohtml
@@ -23,7 +23,7 @@
                 </a>
                 <div class="dropdown-divider"></div>
                 {{if eq .Publication.Status "public"}}
-                <a class="dropdown-item" href="{{index .Constants "frontend-url"}}/publication/{{.Publication.ID}}" target="_blank">
+                <a class="dropdown-item" href="{{.FrontendBaseUrl}}/publication/{{.Publication.ID}}" target="_blank">
                     <i class="if if-book"></i>
                     <span>Public Biblio Location</span>
                 </a>


### PR DESCRIPTION
* adds map `Constants` to the request context. Now only contains `frontend-url`
* fixes #1152: replaces hard coded value `https://biblio.ugent.be` in the views by `{{index .Constants "frontend-url"}}`

Note: I could not replace the frontend-url [here](https://github.com/ugent-library/biblio-backoffice/blob/dev/internal/app/handlers/orcid/handler.go#L228)