### PR TITLE
issue 1160: fix incorrect mapping of (e)issn and (e)isbn in doi import from crossref

### DIFF
--- a/internal/backends/crossref/client.go
+++ b/internal/backends/crossref/client.go
@@ -111,12 +111,30 @@ func (c *Client) GetPublication(id string) (*models.Publication, error) {
 			p.AlternativeTitle = append(p.AlternativeTitle, r.String())
 		}
 	}
-	if res := attrs.Get("ISBN"); res.Exists() {
+	if res := attrs.Get("isbn-type"); res.IsArray() {
+		for _, r := range res.Array() {
+			switch r.Get("type").String() {
+			case "print":
+				p.ISBN = append(p.ISBN, r.Get("value").String())
+			case "electronic":
+				p.EISBN = append(p.EISBN, r.Get("value").String())
+			}
+		}
+	} else if res := attrs.Get("ISBN"); res.Exists() { // TODO: keep fallback?
 		for _, r := range res.Array() {
 			p.ISBN = append(p.ISBN, r.String())
 		}
 	}
-	if res := attrs.Get("ISSN"); res.Exists() {
+	if res := attrs.Get("issn-type"); res.IsArray() {
+		for _, r := range res.Array() {
+			switch r.Get("type").String() {
+			case "print":
+				p.ISSN = append(p.ISSN, r.Get("value").String())
+			case "electronic":
+				p.EISSN = append(p.EISSN, r.Get("value").String())
+			}
+		}
+	} else if res := attrs.Get("ISSN"); res.Exists() { // TODO: keep fallback?
 		for _, r := range res.Array() {
 			p.ISSN = append(p.ISSN, r.String())
 		}


### PR DESCRIPTION
Fixes #1160 

I kept the old code as a fallback, in case fields `isbn-type` and `issn-type`
are not always present.