### PR TITLE
Fixes #1215: Duplicate check on publications via DOI doesn't work any…

### DIFF
--- a/internal/app/handlers/publicationcreating/import.go
+++ b/internal/app/handlers/publicationcreating/import.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -108,9 +109,13 @@ func (h *Handler) AddSingleImportConfirm(w http.ResponseWriter, r *http.Request,
 
 	// check for duplicates
 	if b.Source == "crossref" && b.Identifier != "" {
-		args := models.NewSearchArgs().WithFilter("doi", strings.ToLower(b.Identifier)).WithFilter("status", "public")
+		args := models.NewSearchArgs().WithFilter("identifier", strings.ToLower(b.Identifier)).WithFilter("status", "public")
 
+		log.Printf("%+v", args)
+		log.Println("CHECK CHECK CHECK")
 		existing, err := h.PublicationSearchIndex.Search(args)
+
+		log.Printf("%+v", existing)
 
 		if err != nil {
 			h.Logger.Warnw("import single publication: could not execute search for duplicates", "errors", err, "args", args, "user", ctx.User.ID)


### PR DESCRIPTION
…more

Caused by a change in the ES6 schema here:

https://github.com/ugent-library/biblio-backoffice/commit/fad4a69f37b4a3a47b7cf172625447d49934d072#diff-5cb9e620932dfe0ff54f7e933207e358090a699c494e6a1885c358fc2e9c3cd6L326

The name of the ES6 field was changed from `doi` to `identifier` without making the according change across the codebase. Not too sure if similar problems will pop-up elsewhere too.

@nicolasfranck 