### PR TITLE
hotfix: copy faculty_id to field all

### DIFF
--- a/etc/es6/dataset.json
+++ b/etc/es6/dataset.json
@@ -151,7 +151,8 @@
                     "type": "keyword"
                 },
                 "faculty_id": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "copy_to": "all"
                 },
                 "id": {
                     "type": "keyword"

--- a/etc/es6/publication.json
+++ b/etc/es6/publication.json
@@ -166,7 +166,8 @@
                     "type": "keyword"
                 },
                 "faculty_id": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "copy_to": "all"
                 },
                 "extern": {
                     "type": "boolean"

--- a/internal/backends/es6/indexed_publication.go
+++ b/internal/backends/es6/indexed_publication.go
@@ -33,6 +33,7 @@ type indexedPublication struct {
 	ISXN                    []string `json:"isxn,omitempty"`
 	Keyword                 []string `json:"keyword,omitempty"`
 	LastUserID              string   `json:"last_user_id,omitempty"`
+	Legacy                  bool     `json:"legacy"`
 	Locked                  bool     `json:"locked"`
 	OrganizationID          []string `json:"organization_id,omitempty"`
 	Publication             string   `json:"publication,omitempty"`
@@ -64,6 +65,7 @@ func NewIndexedPublication(p *models.Publication) *indexedPublication {
 		ID:                      p.ID,
 		IssueTitle:              p.IssueTitle,
 		LastUserID:              p.LastUserID,
+		Legacy:                  p.Legacy,
 		Locked:                  p.Locked,
 		HasMessage:              len(p.Message) > 0,
 		Publication:             p.Publication,


### PR DESCRIPTION
Hotfix

Fixes regression as introduced by https://github.com/ugent-library/biblio-backoffice/commit/489bccecad6c183cb5022ecea60404ff02d9dc63

Requires reindexation