### PR TITLE
fix issue 1223

### DIFF
--- a/views/form/cols/select_repeat.gohtml
+++ b/views/form/cols/select_repeat.gohtml
@@ -12,7 +12,7 @@
     <div class="form-values">
         {{range $i, $v := .Values}}
         <div class="d-flex mb-3 form-value">
-            <select class="custom-select form-control" name="{{$.Name}}[{{$i}}]" data-tmpl-name="{{$.Name}}[{i}]">
+            <select class="custom-select form-control" name="{{$.Name}}">
                 {{if $.EmptyOption}}<option></option>{{end}}
                 {{range $.Options}}
                 <option value="{{.Value}}"{{if eq .Value $v}} selected{{end}}>{{.Label}}</option>
@@ -26,7 +26,7 @@
         {{end}}
 
         <div class="d-flex mb-3 form-value">
-            <select class="custom-select form-control" name="{{.Name}}[{{len .Values}}]" data-tmpl-name="{{.Name}}[{i}]">
+            <select class="custom-select form-control" name="{{.Name}}">
                 {{if .EmptyOption}}<option></option>{{end}}
                 {{range .Options}}
                 <option value="{{.Value}}">{{.Label}}</option>

--- a/views/form/cols/text_repeat.gohtml
+++ b/views/form/cols/text_repeat.gohtml
@@ -12,15 +12,16 @@
         {{range $i, $v := .Values}}
         <div class="d-flex mb-3 form-value">
             {{if $.AutocompleteURL}}
-            <div class="w-100 autocomplete" data-target="[name='{{$.Name}}[{{$i}}]']" data-tmpl-data-target="[name='{{$.Name}}[{i}]']">
+            <div class="w-100 autocomplete" data-target="#{{$.Name}}-{{$i}}" data-tmpl-data-target="#{{$.Name}}-{i}">
             {{end}}
-                <input class="form-control{{if $.Error}} is-invalid{{end}}" name="{{$.Name}}[{{$i}}]" data-tmpl-name="{{$.Name}}[{i}]" type="text" value="{{$v}}"
+                <input class="form-control{{if $.Error}} is-invalid{{end}}" name="{{$.Name}}" type="text" value="{{$v}}"
+                    id="{{$.Name}}-{{$i}}" data-tmpl-id="{{$.Name}}-{i}"
                     {{if $.AutocompleteURL}}
                     autocomplete="off"
                     hx-get="{{pathFor $.AutocompleteURL}}"
                     hx-trigger="keyup changed delay:100ms"
                     hx-target="#{{$.Name}}-{{$i}}-autocomplete" data-tmpl-hx-target="#{{$.Name}}-{i}-autocomplete"
-                    hx-vals='{"input": "{{$.Name}}[{{$i}}]"}' data-tmpl-hx-vals='{"input": "{{$.Name}}[{i}]"}'
+                    hx-vals='{"input": "{{$.Name}}"}'
                     {{end}}
                     {{if $.Readonly}}readonly{{end}}
                 >
@@ -36,15 +37,16 @@
         {{end}}
         <div class="d-flex mb-3 form-value">
             {{if .AutocompleteURL}}
-            <div class="w-100 autocomplete" data-target="[name='{{.Name}}[{{len .Values}}]']" data-tmpl-data-target="[name='{{.Name}}[{i}]']">
+            <div class="w-100 autocomplete" data-target="#{{.Name}}-{{len .Values}}" data-tmpl-data-target="#{{.Name}}-{i}">
             {{end}}
-                <input class="form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}[{{len .Values}}]" data-tmpl-name="{{.Name}}[{i}]" type="text"
+                <input class="form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}" type="text"
+                    id="{{.Name}}-{{len .Values}}" data-tmpl-id="{{.Name}}-{i}"
                     {{if .AutocompleteURL}}
                     autocomplete="off"
                     hx-get="{{pathFor .AutocompleteURL}}"
                     hx-trigger="keyup changed delay:100ms"
                     hx-target="#{{.Name}}-{{len .Values}}-autocomplete" data-tmpl-hx-target="#{{.Name}}-{i}-autocomplete"
-                    hx-vals='{"input": "{{.Name}}[{{len .Values}}]"}' data-tmpl-hx-vals='{"input": "{{.Name}}[{i}]"}'
+                    hx-vals='{"input": "{{.Name}}"}'
                     {{end}}
                 >
             {{if .AutocompleteURL}}

--- a/views/form/default/select_repeat.gohtml
+++ b/views/form/default/select_repeat.gohtml
@@ -11,7 +11,7 @@
      <div class="col-lg-{{.Cols}} form-values">
          {{range $i, $v := .Values}}
          <div class="d-flex mb-3 form-value">
-             <select class="custom-select form-control" name="{{$.Name}}[{{$i}}]" data-tmpl-name="{{$.Name}}[{i}]">
+             <select class="custom-select form-control" name="{{$.Name}}">
                  {{if $.EmptyOption}}<option></option>{{end}}
                  {{range $.Options}}
                  <option value="{{.Value}}"{{if eq .Value $v}} selected{{end}}>{{.Label}}</option>
@@ -25,7 +25,7 @@
          {{end}}
  
          <div class="d-flex mb-3 form-value">
-             <select class="custom-select form-control" name="{{.Name}}[{{len .Values}}]" data-tmpl-name="{{.Name}}[{i}]">
+             <select class="custom-select form-control" name="{{.Name}}">
                  {{if .EmptyOption}}<option></option>{{end}}
                  {{range .Options}}
                  <option value="{{.Value}}">{{.Label}}</option>

--- a/views/form/default/text_repeat.gohtml
+++ b/views/form/default/text_repeat.gohtml
@@ -13,15 +13,16 @@
         <div class="form-value">
             <div class="d-flex mb-3">
                 {{if $.AutocompleteURL}}
-                <div class="w-100 autocomplete" data-target="[name='{{$.Name}}[{{$i}}]']" data-tmpl-data-target="[name='{{$.Name}}[{i}]']">
+                <div class="w-100 autocomplete" data-target="#{{$.Name}}-{{$i}}" data-tmpl-data-target="#{{$.Name}}-{i}">
                 {{end}}
-                    <input class="form-control{{if $.Error}} is-invalid{{end}}" name="{{$.Name}}[{{$i}}]" data-tmpl-name="{{$.Name}}[{i}]" type="text" value="{{$v}}"
+                    <input class="form-control{{if $.Error}} is-invalid{{end}}" name="{{$.Name}}" type="text" value="{{$v}}"
+                        data-tmpl-id="{{$.Name}}-{i}" id="{{$.Name}}-{{$i}}"
                         {{if $.AutocompleteURL}}
                         autocomplete="off"
                         hx-get="{{pathFor $.AutocompleteURL}}"
                         hx-trigger="keyup changed delay:100ms"
                         hx-target="#{{$.Name}}-{{$i}}-autocomplete" data-tmpl-hx-target="#{{$.Name}}-{i}-autocomplete"
-                        hx-vals='{"input": "{{$.Name}}[{{$i}}]"}' data-tmpl-hx-vals='{"input": "{{$.Name}}[{i}]"}'
+                        hx-vals='{"input": "{{$.Name}}"}'
                         {{end}}
                         {{if $.Readonly}}readonly{{end}}
                     >
@@ -39,15 +40,16 @@
         <div class="mb-3 form-value">
             <div class="d-flex">
                 {{if .AutocompleteURL}}
-                <div class="w-100 autocomplete" data-target="[name='{{.Name}}[{{len .Values}}]']" data-tmpl-data-target="[name='{{.Name}}[{i}]']">
+                <div class="w-100 autocomplete" data-target="#{{.Name}}-{{len .Values}}" data-tmpl-data-target="#{{.Name}}-{i}">
                 {{end}}
-                    <input class="form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}[{{len .Values}}]" data-tmpl-name="{{.Name}}[{i}]" type="text"
+                    <input class="form-control{{if .Error}} is-invalid{{end}}" name="{{.Name}}" type="text"
+                        id="{{.Name}}-{{len .Values}}" data-tmpl-id="{{$.Name}}-{i}"
                         {{if .AutocompleteURL}}
                         autocomplete="off"
                         hx-get="{{pathFor .AutocompleteURL}}"
                         hx-trigger="keyup changed delay:100ms"
                         hx-target="#{{.Name}}-{{len .Values}}-autocomplete" data-tmpl-hx-target="#{{.Name}}-{i}-autocomplete"
-                        hx-vals='{"input": "{{.Name}}[{{len .Values}}]"}' data-tmpl-hx-vals='{"input": "{{.Name}}[{i}]"}'
+                        hx-vals='{"input": "{{.Name}}"}'
                         {{end}}
                     >
                 {{if .AutocompleteURL}}


### PR DESCRIPTION
fixes #1223

* Removes numeric brackets from input field names
* Added attribute `id` and `data-tmpl-id` for each repeated text input, and used that as data target
* Could not remove numbers from other attributes because the autocomplete functionality heavily depends on it. So cannot remove asset `assets/js/multiple.js` yet.

To be revisited if we ever use structured forms (e.g. multiple abstracts on the same page)