### PR TITLE
data-toggle="dropdown" should be data-bs-toggle="dropdown" now

### DIFF
--- a/views/search/_has_files_facet.gohtml
+++ b/views/search/_has_files_facet.gohtml
@@ -1,6 +1,6 @@
 <div class="dropdown">
     <a class="badge {{if .SearchArgs.HasFilter "has_files"}}bg-primary{{else if .Hits.Facets.has_files.HasMatches}}badge-default{{else}}badge-light{{end}} me-3"
-        data-toggle="dropdown" data-persist="true" aria-haspopup="true"
+        data-bs-toggle="dropdown" data-persist="true" aria-haspopup="true"
         aria-expanded="false" role="button"
     >
         <span class="badge-text">Files</span>


### PR DESCRIPTION
on backoffice.bibliodev.ugent.be, the facet "files" does no longer open on click.
It appears that the data-toggle="dropdown" should be data-bs-toggle="dropdown" now,
a change that was no applied here.