### PR TITLE
Add missing fields to frontoffice record

### DIFF
--- a/backends/authority/project.go
+++ b/backends/authority/project.go
@@ -75,6 +75,18 @@ func (c *Client) GetProject(id string) (*models.Project, error) {
 		p.EUProject.FrameworkProgramme = v.(string)
 	}
 
+	if v, ok := rec["gismo_id"]; ok {
+		p.GISMOID = v.(string)
+	}
+
+	if v, ok := rec["iweto_id"]; ok {
+		p.IWETOID = v.(string)
+	}
+	// iweto_id not filled in everywhere, but should be same as id for now
+	if p.IWETOID == "" {
+		p.IWETOID = p.ID
+	}
+
 	return p, nil
 }
 

--- a/frontoffice/record.go
+++ b/frontoffice/record.go
@@ -104,10 +104,17 @@ type Parent struct {
 }
 
 type Project struct {
-	ID        string `json:"_id"`
-	Title     string `json:"title,omitempty"`
-	StartDate string `json:"start_date,omitempty"`
-	EndDate   string `json:"end_date,omitempty"`
+	ID                   string `json:"_id"`
+	Title                string `json:"title,omitempty"`
+	StartDate            string `json:"start_date,omitempty"`
+	EndDate              string `json:"end_date,omitempty"`
+	EUID                 string `json:"eu_id,omitempty"`
+	EUCallID             string `json:"eu_call_id,omitempty"`
+	EUFrameworkProgramme string `json:"eu_framework_programme,omitempty"`
+	EUAcronym            string `json:"eu_acronym,omitempty"`
+	GISMOID              string `json:"gismo_id,omitempty"`
+	IWETOID              string `json:"iweto_id,omitempty"`
+	Abstract             string `json:"abstract,omitempty"`
 }
 
 type Publisher struct {
@@ -569,12 +576,21 @@ func MapPublication(p *models.Publication, repo *repositories.Repo) *Record {
 	if p.RelatedProjects != nil {
 		rec.Project = make([]Project, len(p.RelatedProjects))
 		for i, v := range p.RelatedProjects {
-			rec.Project[i] = Project{
+			p := Project{
 				ID:        v.ProjectID,
 				Title:     v.Project.Title,
 				StartDate: v.Project.StartDate,
 				EndDate:   v.Project.EndDate,
+				GISMOID:   v.Project.GISMOID,
+				IWETOID:   v.Project.IWETOID,
 			}
+			if eu := v.Project.EUProject; eu != nil {
+				p.EUID = eu.ID
+				p.EUCallID = eu.CallID
+				p.EUAcronym = eu.Acronym
+				p.EUFrameworkProgramme = eu.FrameworkProgramme
+			}
+			rec.Project[i] = p
 		}
 	}
 

--- a/models/project.go
+++ b/models/project.go
@@ -10,6 +10,8 @@ type Project struct {
 	DateCreated *time.Time `json:"date_created,omitempty"`
 	DateUpdated *time.Time `json:"date_updated,omitempty"`
 	EUProject   *EUProject `json:"eu,omitempty"`
+	GISMOID     string     `json:"gismo_id,omitempty"`
+	IWETOID     string     `json:"iweto_id,omitempty"`
 }
 
 type EUProject struct {


### PR DESCRIPTION
Added missing fields for frontoffice record:

* `eu_id`
* `eu_call_id`
* `eu_acronym`
* `eu_framework_programme`
* `gismo_id`
* `iweto_id` (same as `id` useful in the future

For the last two I had to update the models.Project struct,
but that has no database implication as the record is always
lively fetched.

Ignored field `abstract` as that has no real use as a subfield of a publication