### PR TITLE
fix issue 1299: cap page to last page when out of range

### DIFF
--- a/handlers/datasetsearching/search.go
+++ b/handlers/datasetsearching/search.go
@@ -89,6 +89,15 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request, ctx Context) {
 		isFirstUse = globalHits.Total == 0
 	}
 
+	// you are on the wrong page: cap page to last available page
+	if hits.Total > 0 && len(hits.Hits) == 0 {
+		query := ctx.CurrentURL.Query()
+		query.Set("page", fmt.Sprintf("%d", hits.TotalPages()))
+		ctx.CurrentURL.RawQuery = query.Encode()
+		http.Redirect(w, r, ctx.CurrentURL.String(), http.StatusTemporaryRedirect)
+		return
+	}
+
 	render.Layout(w, "layouts/default", "dataset/pages/search", YieldSearch{
 		Context:      ctx,
 		PageTitle:    "Overview - Datasets - Biblio",
@@ -148,6 +157,15 @@ func (h *Handler) CurationSearch(w http.ResponseWriter, r *http.Request, ctx Con
 			return
 		}
 		isFirstUse = globalHits.Total == 0
+	}
+
+	// you are on the wrong page: cap page to last available page
+	if hits.Total > 0 && len(hits.Hits) == 0 {
+		query := ctx.CurrentURL.Query()
+		query.Set("page", fmt.Sprintf("%d", hits.TotalPages()))
+		ctx.CurrentURL.RawQuery = query.Encode()
+		http.Redirect(w, r, ctx.CurrentURL.String(), http.StatusTemporaryRedirect)
+		return
 	}
 
 	render.Layout(w, "layouts/default", "dataset/pages/search", YieldSearch{

--- a/handlers/publicationsearching/search.go
+++ b/handlers/publicationsearching/search.go
@@ -90,6 +90,15 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request, ctx Context) {
 		isFirstUse = globalHits.Total == 0
 	}
 
+	// you are on the wrong page: cap page to last available page
+	if hits.Total > 0 && len(hits.Hits) == 0 {
+		query := ctx.CurrentURL.Query()
+		query.Set("page", fmt.Sprintf("%d", hits.TotalPages()))
+		ctx.CurrentURL.RawQuery = query.Encode()
+		http.Redirect(w, r, ctx.CurrentURL.String(), http.StatusTemporaryRedirect)
+		return
+	}
+
 	render.Layout(w, "layouts/default", "publication/pages/search", YieldSearch{
 		Context:      ctx,
 		PageTitle:    "Overview - Publications - Biblio",
@@ -149,6 +158,15 @@ func (h *Handler) CurationSearch(w http.ResponseWriter, r *http.Request, ctx Con
 			return
 		}
 		isFirstUse = globalHits.Total == 0
+	}
+
+	// you are on the wrong page: cap page to last available page
+	if hits.Total > 0 && len(hits.Hits) == 0 {
+		query := ctx.CurrentURL.Query()
+		query.Set("page", fmt.Sprintf("%d", hits.TotalPages()))
+		ctx.CurrentURL.RawQuery = query.Encode()
+		http.Redirect(w, r, ctx.CurrentURL.String(), http.StatusTemporaryRedirect)
+		return
 	}
 
 	render.Layout(w, "layouts/default", "publication/pages/search", YieldSearch{


### PR DESCRIPTION
fixes #1299 by truncating requested `page` to last available page (note: only when there are results available). Other out of range requests like a negative number may result in a http status 500 request.