### PR TITLE
Make sure sidebar switches colours again like before

### DIFF
--- a/views/layouts/default.layout.gohtml
+++ b/views/layouts/default.layout.gohtml
@@ -119,7 +119,7 @@
     </header>
     <main>
         <div class="d-flex u-maximize-height">
-            <div class="c-sidebar {{if and .User .User.CanCurate (eq .UserRole "curator")}} c-sidebar--dark-gray {{end}}">
+            <div class="c-sidebar {{if eq .UserRole "curator"}} c-sidebar--dark-gray{{end}}">
                 {{if and .User .User.CanCurate}}
                 <div class="dropdown mx-lg-4 mb-6 mt-3">
                     <button class="btn btn-outline-light dropdown-toggle w-100 d-flex align-items-center justify-content-center" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
Context: This needs to be merged in dev later, where the strange behaviour still needs to be fixed in a different file.
Not sure if this is the correct way to do it (e.g. should I define user as well), could not find how it was done before. It does show the correct behaviour:

![Screenshot 2023-11-09 at 12 02 12](https://github.com/ugent-library/biblio-backoffice/assets/1572885/4c307f23-35af-49dc-b239-526cbb535fc7)
![Screenshot 2023-11-09 at 12 02 19](https://github.com/ugent-library/biblio-backoffice/assets/1572885/bf829786-4c92-4f59-8271-711f526f0b61)
