### PR TITLE
fix issue 1310: add batch method `status.set`

### DIFF
--- a/cli/backends.go
+++ b/cli/backends.go
@@ -330,6 +330,7 @@ func newRepo(personService backends.PersonService, organizationService backends.
 			"eissn.add":                mutate.EISSNAdd,
 			"eissn.remove":             mutate.EISSNRemove,
 			"external_fields.set":      mutate.ExternalFieldsSet,
+			"status.set":               mutate.StatusSet,
 		},
 	})
 

--- a/mutate/publication.go
+++ b/mutate/publication.go
@@ -227,3 +227,20 @@ func ExternalFieldsSet(p *models.Publication, args []string) error {
 	p.ExternalFields.SetAll(args[0], args[1:]...)
 	return nil
 }
+
+func StatusSet(p *models.Publication, args []string) error {
+	if len(args) < 1 {
+		return errors.New("no status given")
+	}
+	switch args[0] {
+	case "private":
+		p.Status = "private"
+	case "public":
+		p.Status = "public"
+	case "returned":
+		p.Status = "returned"
+	default:
+		return errors.New("invalid status given")
+	}
+	return nil
+}

--- a/mutate/publication.go
+++ b/mutate/publication.go
@@ -232,15 +232,6 @@ func StatusSet(p *models.Publication, args []string) error {
 	if len(args) < 1 {
 		return errors.New("no status given")
 	}
-	switch args[0] {
-	case "private":
-		p.Status = "private"
-	case "public":
-		p.Status = "public"
-	case "returned":
-		p.Status = "returned"
-	default:
-		return errors.New("invalid status given")
-	}
+	p.Status = args[0]
 	return nil
 }


### PR DESCRIPTION
fixes #1310 

note:

* only internal values `private`, `public` and `returned` are used.
* internal store validates the record, so one cannot just a record to public without an ugent author for example