### PR TITLE
Always show withdraw button for librarians

### DIFF
--- a/handlers/datasetediting/publish.go
+++ b/handlers/datasetediting/publish.go
@@ -27,7 +27,7 @@ func (h *Handler) ConfirmPublish(w http.ResponseWriter, r *http.Request, ctx Con
 }
 
 func (h *Handler) Publish(w http.ResponseWriter, r *http.Request, ctx Context) {
-	if !ctx.User.CanEditDataset(ctx.Dataset) {
+	if !ctx.User.CanPublishDataset(ctx.Dataset) {
 		h.Logger.Warnw("publish dataset: user has no permission to publish", "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
 		render.Forbidden(w, r)
 		return

--- a/handlers/datasetediting/republish.go
+++ b/handlers/datasetediting/republish.go
@@ -27,7 +27,7 @@ func (h *Handler) ConfirmRepublish(w http.ResponseWriter, r *http.Request, ctx C
 }
 
 func (h *Handler) Republish(w http.ResponseWriter, r *http.Request, ctx Context) {
-	if !ctx.User.CanEditDataset(ctx.Dataset) {
+	if !ctx.User.CanPublishDataset(ctx.Dataset) {
 		h.Logger.Warnw("republish dataset: user has no permission to republish", "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
 		render.Forbidden(w, r)
 		return

--- a/handlers/datasetediting/withdraw.go
+++ b/handlers/datasetediting/withdraw.go
@@ -27,7 +27,7 @@ func (h *Handler) ConfirmWithdraw(w http.ResponseWriter, r *http.Request, ctx Co
 }
 
 func (h *Handler) Withdraw(w http.ResponseWriter, r *http.Request, ctx Context) {
-	if !ctx.User.CanEditDataset(ctx.Dataset) {
+	if !ctx.User.CanWithdrawDataset(ctx.Dataset) {
 		h.Logger.Warnw("withdraw dataset: user has no permission to withdraw", "dataset", ctx.Dataset.ID, "user", ctx.User.ID)
 		render.Forbidden(w, r)
 		return

--- a/handlers/publicationcreating/import.go
+++ b/handlers/publicationcreating/import.go
@@ -259,7 +259,7 @@ func (h *Handler) AddSingleConfirm(w http.ResponseWriter, r *http.Request, ctx C
 }
 
 func (h *Handler) AddSinglePublish(w http.ResponseWriter, r *http.Request, ctx Context) {
-	if !ctx.User.CanEditPublication(ctx.Publication) {
+	if !ctx.User.CanPublishPublication(ctx.Publication) {
 		h.Logger.Warnw("add single publication publish: user has no permission to publish publication.", "publication", ctx.Publication.ID, "user", ctx.User.ID)
 		render.Forbidden(w, r)
 		return

--- a/handlers/publicationediting/republish.go
+++ b/handlers/publicationediting/republish.go
@@ -27,7 +27,7 @@ func (h *Handler) ConfirmRepublish(w http.ResponseWriter, r *http.Request, ctx C
 }
 
 func (h *Handler) Republish(w http.ResponseWriter, r *http.Request, ctx Context) {
-	if !ctx.User.CanEditPublication(ctx.Publication) {
+	if !ctx.User.CanPublishPublication(ctx.Publication) {
 		h.Logger.Warnw("republish publication: user has no permission to republish", "user", ctx.User.ID, "publication", ctx.Publication.ID)
 		render.Forbidden(w, r)
 		return

--- a/handlers/publicationediting/withdraw.go
+++ b/handlers/publicationediting/withdraw.go
@@ -27,7 +27,7 @@ func (h *Handler) ConfirmWithdraw(w http.ResponseWriter, r *http.Request, ctx Co
 }
 
 func (h *Handler) Withdraw(w http.ResponseWriter, r *http.Request, ctx Context) {
-	if !ctx.User.CanEditPublication(ctx.Publication) {
+	if !ctx.User.CanWithdrawPublication(ctx.Publication) {
 		h.Logger.Warnw("witdraw publication: user has no permission to withdraw", "user", ctx.User.ID, "publication", ctx.Publication.ID)
 		render.Forbidden(w, r)
 		return

--- a/models/person.go
+++ b/models/person.go
@@ -56,6 +56,14 @@ func (u *Person) CanViewPublication(p *Publication) bool {
 	return false
 }
 
+func (u *Person) CanWithdrawPublication(p *Publication) bool {
+	return p.Status == "public" && u.CanEditPublication(p)
+}
+
+func (u *Person) CanPublishPublication(p *Publication) bool {
+	return p.Status != "public" && u.CanEditPublication(p)
+}
+
 func (u *Person) CanEditPublication(p *Publication) bool {
 	if !u.Active {
 		return false
@@ -136,6 +144,14 @@ func (u *Person) CanViewDataset(d *Dataset) bool {
 		}
 	}
 	return false
+}
+
+func (u *Person) CanWithdrawDataset(d *Dataset) bool {
+	return d.Status == "public" && u.CanEditDataset(d)
+}
+
+func (u *Person) CanPublishDataset(d *Dataset) bool {
+	return d.Status != "public" && u.CanEditDataset(d)
 }
 
 func (u *Person) CanEditDataset(d *Dataset) bool {

--- a/views/dataset/pages/show.gohtml
+++ b/views/dataset/pages/show.gohtml
@@ -12,16 +12,28 @@
                     </div>
                 </div>
                 <div class="bc-toolbar-right">
-                   {{if and (.User.CanEditDataset .Dataset) (eq .Dataset.Status "public") (not .Dataset.Locked)}}
-                    <div class="bc-toolbar-item">
-                        <button class="btn btn-outline-danger"
-                            hx-get="{{pathFor "dataset_confirm_withdraw" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
-                            hx-target="#modals"
-                        >
-                            <i class="if if-arrow-go-back"></I>
-                            <span class="btn-text">Withdraw</span>
-                        </button>
-                    </div>
+                    {{if eq .Dataset.Status "public"}}
+                        {{if and (.User.CanEditDataset .Dataset) (not .Dataset.Locked)}}
+                        <div class="bc-toolbar-item">
+                            <button class="btn btn-outline-danger"
+                                hx-get="{{pathFor "dataset_confirm_withdraw" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
+                                hx-target="#modals"
+                            >
+                                <i class="if if-arrow-go-back"></I>
+                                <span class="btn-text">Withdraw</span>
+                            </button>
+                        </div>
+                        {{else if .User.CanCurate}}
+                        <div class="bc-toolbar-item">
+                            <button class="btn btn-outline-danger"
+                                hx-get="{{pathFor "dataset_confirm_withdraw" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
+                                hx-target="#modals"
+                            >
+                                <i class="if if-arrow-go-back"></I>
+                                <span class="btn-text">Withdraw</span>
+                            </button>
+                        </div>
+                        {{end}}
                     {{end}}
                     {{if and (.User.CanEditDataset .Dataset) (eq .Dataset.Status "returned") (not .Dataset.Locked)}}
                     <div class="bc-toolbar-item">

--- a/views/dataset/pages/show.gohtml
+++ b/views/dataset/pages/show.gohtml
@@ -19,7 +19,7 @@
                                 hx-get="{{pathFor "dataset_confirm_withdraw" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
                                 hx-target="#modals"
                             >
-                                <i class="if if-arrow-go-back"></I>
+                                <i class="if if-arrow-go-back"></i>
                                 <span class="btn-text">Withdraw</span>
                             </button>
                         </div>
@@ -29,7 +29,7 @@
                                 hx-get="{{pathFor "dataset_confirm_withdraw" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
                                 hx-target="#modals"
                             >
-                                <i class="if if-arrow-go-back"></I>
+                                <i class="if if-arrow-go-back"></i>
                                 <span class="btn-text">Withdraw</span>
                             </button>
                         </div>
@@ -61,7 +61,7 @@
                             hx-post="{{pathFor "dataset_unlock" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
                             hx-swap="none"
                         >
-                            <i class="if if-lock-unlock"></I>
+                            <i class="if if-lock-unlock"></i>
                             <span class="btn-text">Unlock record</span>
                         </button>
                         {{else if .User.CanCurate}}
@@ -69,7 +69,7 @@
                             hx-post="{{pathFor "dataset_lock" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
                             hx-swap="none"
                         >
-                            <i class="if if-lock"></I>
+                            <i class="if if-lock"></i>
                             <span class="btn-text">Lock record</span>
                         </button>
                         {{end}}

--- a/views/dataset/pages/show.gohtml
+++ b/views/dataset/pages/show.gohtml
@@ -12,30 +12,18 @@
                     </div>
                 </div>
                 <div class="bc-toolbar-right">
-                    {{if eq .Dataset.Status "public"}}
-                        {{if and (.User.CanEditDataset .Dataset) (not .Dataset.Locked)}}
-                        <div class="bc-toolbar-item">
-                            <button class="btn btn-outline-danger"
-                                hx-get="{{pathFor "dataset_confirm_withdraw" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
-                                hx-target="#modals"
-                            >
-                                <i class="if if-arrow-go-back"></i>
-                                <span class="btn-text">Withdraw</span>
-                            </button>
-                        </div>
-                        {{else if .User.CanCurate}}
-                        <div class="bc-toolbar-item">
-                            <button class="btn btn-outline-danger"
-                                hx-get="{{pathFor "dataset_confirm_withdraw" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
-                                hx-target="#modals"
-                            >
-                                <i class="if if-arrow-go-back"></i>
-                                <span class="btn-text">Withdraw</span>
-                            </button>
-                        </div>
-                        {{end}}
+                    {{if .User.CanWithdrawDataset .Dataset}}
+                    <div class="bc-toolbar-item">
+                        <button class="btn btn-outline-danger"
+                            hx-get="{{pathFor "dataset_confirm_withdraw" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
+                            hx-target="#modals"
+                        >
+                            <i class="if if-arrow-go-back"></i>
+                            <span class="btn-text">Withdraw</span>
+                        </button>
+                    </div>  
                     {{end}}
-                    {{if and (.User.CanEditDataset .Dataset) (eq .Dataset.Status "returned") (not .Dataset.Locked)}}
+                    {{if and (.User.CanPublishDataset .Dataset) (eq .Dataset.Status "returned")}}
                     <div class="bc-toolbar-item">
                         <button class="btn btn-success"
                             hx-get="{{pathFor "dataset_confirm_republish" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"
@@ -45,7 +33,7 @@
                         </button>
                     </div>
                     {{end}}
-                    {{if and (.User.CanEditDataset .Dataset) (ne .Dataset.Status "returned") (ne .Dataset.Status "public") (not .Dataset.Locked)}}
+                    {{if and (.User.CanPublishDataset .Dataset) (ne .Dataset.Status "returned")}}
                     <div class="bc-toolbar-item">
                         <button class="btn btn-success"
                             hx-get="{{pathFor "dataset_confirm_publish" "id" .Dataset.ID|querySet "redirect-url" .CurrentURL.String}}"

--- a/views/publication/pages/show.gohtml
+++ b/views/publication/pages/show.gohtml
@@ -12,30 +12,18 @@
                     </div>
                 </div>
                 <div class="bc-toolbar-right">
-                    {{if eq .Publication.Status "public"}}
-                        {{if and (.User.CanEditPublication .Publication) (not .Publication.Locked)}}
-                        <div class="bc-toolbar-item">
-                            <button class="btn btn-outline-danger"
-                                hx-get="{{pathFor "publication_confirm_withdraw" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
-                                hx-target="#modals"
-                            >
-                                <i class="if if-arrow-go-back"></i>
-                                <span class="btn-text">Withdraw</span>
-                            </button>
-                        </div>
-                        {{else if .User.CanCurate}}
-                        <div class="bc-toolbar-item">
-                            <button class="btn btn-outline-danger"
-                                hx-get="{{pathFor "publication_confirm_withdraw" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
-                                hx-target="#modals"
-                            >
-                                <i class="if if-arrow-go-back"></i>
-                                <span class="btn-text">Withdraw</span>
-                            </button>
-                        </div>
-                        {{end}}
+                    {{if .User.CanWithdrawPublication .Publication}}
+                    <div class="bc-toolbar-item">
+                        <button class="btn btn-outline-danger"
+                            hx-get="{{pathFor "publication_confirm_withdraw" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
+                            hx-target="#modals"
+                        >
+                            <i class="if if-arrow-go-back"></i>
+                            <span class="btn-text">Withdraw</span>
+                        </button>
+                    </div>
                     {{end}}
-                    {{if and (.User.CanEditPublication .Publication) (eq .Publication.Status "returned") (not .Publication.Locked)}}
+                    {{if and (.User.CanPublishPublication .Publication) (eq .Publication.Status "returned")}}
                     <div class="bc-toolbar-item">
                         <button class="btn btn-success"
                             hx-get="{{pathFor "publication_confirm_republish" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
@@ -45,7 +33,7 @@
                         </button>
                     </div>
                     {{end}}
-                    {{if and (.User.CanEditPublication .Publication) (ne .Publication.Status "returned") (ne .Publication.Status "public") (not .Publication.Locked)}}
+                    {{if and (.User.CanPublishPublication .Publication) (ne .Publication.Status "returned")}}
                     <div class="bc-toolbar-item">
                         <button class="btn btn-success"
                             hx-get="{{pathFor "publication_confirm_publish" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"

--- a/views/publication/pages/show.gohtml
+++ b/views/publication/pages/show.gohtml
@@ -19,7 +19,7 @@
                                 hx-get="{{pathFor "publication_confirm_withdraw" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
                                 hx-target="#modals"
                             >
-                                <i class="if if-arrow-go-back"></I>
+                                <i class="if if-arrow-go-back"></i>
                                 <span class="btn-text">Withdraw</span>
                             </button>
                         </div>
@@ -29,7 +29,7 @@
                                 hx-get="{{pathFor "publication_confirm_withdraw" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
                                 hx-target="#modals"
                             >
-                                <i class="if if-arrow-go-back"></I>
+                                <i class="if if-arrow-go-back"></i>
                                 <span class="btn-text">Withdraw</span>
                             </button>
                         </div>
@@ -62,7 +62,7 @@
                             hx-post="{{pathFor "publication_unlock" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
                             hx-swap="none"
                         >
-                            <i class="if if-lock-unlock"></I>
+                            <i class="if if-lock-unlock"></i>
                             <span class="btn-text">Unlock record</span>
                         </button>
                         {{else if .User.CanCurate}}
@@ -70,7 +70,7 @@
                             hx-post="{{pathFor "publication_lock" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
                             hx-swap="none"
                         >
-                            <i class="if if-lock"></I>
+                            <i class="if if-lock"></i>
                             <span class="btn-text">Lock record</span>
                         </button>
                         {{end}}

--- a/views/publication/pages/show.gohtml
+++ b/views/publication/pages/show.gohtml
@@ -12,16 +12,28 @@
                     </div>
                 </div>
                 <div class="bc-toolbar-right">
-                   {{if and (.User.CanEditPublication .Publication) (eq .Publication.Status "public") (not .Publication.Locked)}}
-                    <div class="bc-toolbar-item">
-                        <button class="btn btn-outline-danger"
-                            hx-get="{{pathFor "publication_confirm_withdraw" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
-                            hx-target="#modals"
-                        >
-                            <i class="if if-arrow-go-back"></I>
-                            <span class="btn-text">Withdraw</span>
-                        </button>
-                    </div>
+                    {{if eq .Publication.Status "public"}}
+                        {{if and (.User.CanEditPublication .Publication) (not .Publication.Locked)}}
+                        <div class="bc-toolbar-item">
+                            <button class="btn btn-outline-danger"
+                                hx-get="{{pathFor "publication_confirm_withdraw" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
+                                hx-target="#modals"
+                            >
+                                <i class="if if-arrow-go-back"></I>
+                                <span class="btn-text">Withdraw</span>
+                            </button>
+                        </div>
+                        {{else if .User.CanCurate}}
+                        <div class="bc-toolbar-item">
+                            <button class="btn btn-outline-danger"
+                                hx-get="{{pathFor "publication_confirm_withdraw" "id" .Publication.ID|querySet "redirect-url" .CurrentURL.String}}"
+                                hx-target="#modals"
+                            >
+                                <i class="if if-arrow-go-back"></I>
+                                <span class="btn-text">Withdraw</span>
+                            </button>
+                        </div>
+                        {{end}}
                     {{end}}
                     {{if and (.User.CanEditPublication .Publication) (eq .Publication.Status "returned") (not .Publication.Locked)}}
                     <div class="bc-toolbar-item">


### PR DESCRIPTION
Should fix https://github.com/ugent-library/biblio-backoffice/issues/851

Shows withdraw button for librarians even when locked
- "view as" does not work locally; so not sure if this works as expected for researchers. The withdrawn button should _not_ show up for researchers when the publication or dataset is locked.
- Nested it in a dumb way and could use some more simple if-else love, but got stuck along the way. Any tips?