### PR TITLE
oai review

### DIFF
--- a/backends/mods36/encoder.go
+++ b/backends/mods36/encoder.go
@@ -69,6 +69,7 @@ var tmpl = template.Must(template.New("").Funcs(funcs).Parse(`
     xmlns="http://www.loc.gov/mods/v3"
     xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd"
 >
+	<identifier type="hdl">http://hdl.handle.net/1854/LU-{{.Rec.ID | xml}}</identifier>
 	{{range .Rec.DOI}}
 	<identifier type="doi">{{. | xml }}</identifier>
 	{{end}}
@@ -285,7 +286,7 @@ var tmpl = template.Must(template.New("").Funcs(funcs).Parse(`
 				<placeTerm>{{.Rec.Publisher.Location | xml}}</placeTerm>
 			</place>
 			{{end}}
-			{{if and .Rec.Publisher .Rec.Publisher.Location}}
+			{{if and .Rec.Publisher .Rec.Publisher.Name}}
 			<publisher>{{.Rec.Publisher.Name | xml}}</publisher>
 			{{end}}
 			<dateIssued encoding="w3cdtf">{{.Rec.Year | xml}}</dateIssued>
@@ -371,7 +372,7 @@ var tmpl = template.Must(template.New("").Funcs(funcs).Parse(`
 					<placeTerm>{{.Rec.Publisher.Location | xml}}</placeTerm>
 				</place>
 				{{end}}
-				{{if and .Rec.Publisher .Rec.Publisher.Location}}
+				{{if and .Rec.Publisher .Rec.Publisher.Name}}
 				<publisher>{{.Rec.Publisher.Name | xml}}</publisher>
 				{{end}}
 				<dateIssued encoding="w3cdtf">{{.Rec.Year | xml}}</dateIssued>
@@ -439,7 +440,7 @@ var tmpl = template.Must(template.New("").Funcs(funcs).Parse(`
 				<placeTerm>{{.Rec.Publisher.Location | xml}}</placeTerm>
 			</place>
 			{{end}}
-			{{if and .Rec.Publisher .Rec.Publisher.Location}}
+			{{if and .Rec.Publisher .Rec.Publisher.Name}}
 			<publisher>{{.Rec.Publisher.Name | xml}}</publisher>
 			{{end}}
 			<dateIssued encoding="w3cdtf">{{.Rec.Year | xml}}</dateIssued>

--- a/backends/oaidc/encoder.go
+++ b/backends/oaidc/encoder.go
@@ -85,7 +85,7 @@ func (e *Encoder) encode(r *frontoffice.Record) ([]byte, error) {
 	}
 
 	switch r.PublicationStatus {
-	case "unsubmitted":
+	case "unpublished":
 		writeField(b, "type", "info:eu-repo/semantics/draft")
 	case "inpress":
 		writeField(b, "type", "info:eu-repo/semantics/acceptedVersion")

--- a/cli/update_oai_cmd.go
+++ b/cli/update_oai_cmd.go
@@ -111,12 +111,15 @@ var updateOai = &cobra.Command{
 			oaiID := "oai:archive.ugent.be:" + p.ID
 
 			if p.Status == "deleted" && p.HasBeenPublic {
-				err = client.DeleteRecord(context.TODO(), &api.DeleteRecordRequest{
-					Identifier: oaiID,
-				})
-				if err != nil {
-					// TODO
-					logger.Fatal(err)
+				for _, metadataPrefix := range []string{"oai_dc", "mods_36"} {
+					err = client.DeleteRecord(context.TODO(), &api.DeleteRecordRequest{
+						Identifier:     oaiID,
+						MetadataPrefix: metadataPrefix,
+					})
+					if err != nil {
+						// TODO
+						logger.Fatal(err)
+					}
 				}
 				return true
 			}
@@ -194,12 +197,15 @@ var updateOai = &cobra.Command{
 			oaiID := "oai:archive.ugent.be:" + d.ID
 
 			if d.Status == "deleted" && d.HasBeenPublic {
-				err = client.DeleteRecord(context.TODO(), &api.DeleteRecordRequest{
-					Identifier: oaiID,
-				})
-				if err != nil {
-					// TODO
-					logger.Fatal(err)
+				for _, metadataPrefix := range []string{"oai_dc", "mods_36"} {
+					err = client.DeleteRecord(context.TODO(), &api.DeleteRecordRequest{
+						Identifier:     oaiID,
+						MetadataPrefix: metadataPrefix,
+					})
+					if err != nil {
+						// TODO
+						logger.Fatal(err)
+					}
 				}
 				return true
 			}


### PR DESCRIPTION
* reviewed oai_dc and mods_36 conversion in comparison to old conversion
* added required field `MetadataPrefix` to delete record request, and did this for all inserted formats. See also change in oai-service that retroactively inserts records with this method