### PR TITLE
pdeleted misses "returned"; fix missing pdeleted for frontoffice too

### DIFF
--- a/cli/update_oai.go
+++ b/cli/update_oai.go
@@ -112,7 +112,7 @@ var updateOai = &cobra.Command{
 		repo.EachPublication(func(p *models.Publication) bool {
 			oaiID := "oai:archive.ugent.be:" + p.ID
 
-			if p.Status == "deleted" && p.HasBeenPublic {
+			if p.HasBeenPublic && p.Status != "public" {
 				for _, metadataPrefix := range []string{"oai_dc", "mods_36"} {
 					err = client.DeleteRecord(context.TODO(), &api.DeleteRecordRequest{
 						Identifier:     oaiID,
@@ -209,7 +209,7 @@ var updateOai = &cobra.Command{
 		repo.EachDataset(func(d *models.Dataset) bool {
 			oaiID := "oai:archive.ugent.be:" + d.ID
 
-			if d.Status == "deleted" && d.HasBeenPublic {
+			if d.HasBeenPublic && d.Status != "public" {
 				for _, metadataPrefix := range []string{"oai_dc", "mods_36"} {
 					err = client.DeleteRecord(context.TODO(), &api.DeleteRecordRequest{
 						Identifier:     oaiID,
@@ -252,6 +252,15 @@ var updateOai = &cobra.Command{
 				Identifier:     oaiID,
 				MetadataPrefix: "mods_36",
 				Content:        string(metadata),
+			})
+			if err != nil {
+				// TODO
+				logger.Fatal(err)
+			}
+
+			err = client.AddItem(context.TODO(), &api.AddItemRequest{
+				Identifier: oaiID,
+				SetSpecs:   []string{},
 			})
 			if err != nil {
 				// TODO

--- a/frontoffice/record.go
+++ b/frontoffice/record.go
@@ -452,7 +452,7 @@ func MapPublication(p *models.Publication, repo *repositories.Repo) *Record {
 
 	if p.Status == "private" {
 		rec.Status = "unsubmitted"
-	} else if p.Status == "deleted" && p.HasBeenPublic {
+	} else if p.HasBeenPublic && p.Status != "public" {
 		rec.Status = "pdeleted"
 	} else {
 		rec.Status = p.Status
@@ -967,7 +967,7 @@ func MapDataset(d *models.Dataset, repo *repositories.Repo) *Record {
 
 	if d.Status == "private" {
 		rec.Status = "unsubmitted"
-	} else if d.Status == "deleted" && d.HasBeenPublic {
+	} else if d.HasBeenPublic && d.Status != "public" {
 		rec.Status = "pdeleted"
 	} else {
 		rec.Status = d.Status


### PR DESCRIPTION
* `update-oai` command misses `AddItem` call due to which we missed records
* `update-oai` only uses deleted records as `pdeleted`, and therefore we miss records with status `returned`. That being said, this is also the case for the frontoffice code, where we do the same (pdeleted -> `status == "deleted" && has_been_public == true`). Should be derived as follows: `has_been_public == true && status != "public"`. This way we also fix the records in the current frontoffice oai