### PR TITLE
fix issue 1360

### DIFF
--- a/frontoffice/record.go
+++ b/frontoffice/record.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/caltechlibrary/doitools"
 	"github.com/iancoleman/strcase"
+	"github.com/ugent-library/biblio-backoffice/identifiers"
 	"github.com/ugent-library/biblio-backoffice/models"
 	"github.com/ugent-library/biblio-backoffice/repositories"
 	"github.com/ugent-library/biblio-backoffice/validation"
@@ -171,6 +172,12 @@ type JCR struct {
 	PrevCategoryQuartile *int     `json:"prev_category_quartile,omitempty"`
 }
 
+type Identifier struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+	URL   string `json:"url,omitempty"`
+}
+
 type Record struct {
 	ID                  string               `json:"_id"`
 	Abstract            []string             `json:"abstract,omitempty"`
@@ -206,6 +213,7 @@ type Record struct {
 	FirstAuthor         []Person             `json:"first_author,omitempty"`
 	Format              []string             `json:"format,omitempty"`
 	Handle              string               `json:"handle,omitempty"`
+	Identifier          []Identifier         `json:"identifier,omitempty"`
 	ISBN                []string             `json:"isbn,omitempty"`
 	ISSN                []string             `json:"issn,omitempty"`
 	Issue               string               `json:"issue,omitempty"`
@@ -913,6 +921,16 @@ func MapDataset(d *models.Dataset, repo *repositories.Repo) *Record {
 			rec.DOI = append(rec.DOI, val)
 		} else {
 			rec.DOI = append(rec.DOI, doi)
+		}
+	}
+
+	for typ, values := range d.Identifiers {
+		for _, value := range values {
+			rec.Identifier = append(rec.Identifier, Identifier{
+				Type:  typ,
+				Value: value,
+				URL:   identifiers.Resolve(typ, value),
+			})
 		}
 	}
 

--- a/identifiers/ega.go
+++ b/identifiers/ega.go
@@ -1,0 +1,15 @@
+package identifiers
+
+type EGAType struct{}
+
+func (i *EGAType) Validate(id string) bool {
+	return true
+}
+
+func (i *EGAType) Normalize(id string) (string, error) {
+	return id, nil
+}
+
+func (i *EGAType) Resolve(id string) string {
+	return "https://ega-archive.org/datasets/" + id
+}

--- a/identifiers/identifier.go
+++ b/identifiers/identifier.go
@@ -5,6 +5,7 @@ var (
 	DOI           = &DOIType{}
 	ENA           = &ENAType{}
 	ENABioProject = &ENABioProjectType{}
+	EGA           = &EGAType{}
 	Ensembl       = &EnsemblType{}
 	Handle        = &HandleType{}
 	PubMed        = &PubMedType{}
@@ -14,6 +15,7 @@ var (
 var types = map[string]Type{
 	"BioStudies":    BioStudies,
 	"DOI":           DOI,
+	"EGA":           EGA,
 	"ENA":           ENA,
 	"ENABioProject": ENABioProject,
 	"Ensembl":       Ensembl,

--- a/locales/en/default.po
+++ b/locales/en/default.po
@@ -2348,6 +2348,9 @@ msgstr "DOI"
 msgid "identifier.ENA"
 msgstr "ENA"
 
+msgid "identifier.EGA"
+msgstr "EGA"
+
 msgid "identifier.ENABioProject"
 msgstr "ENA BioProject"
 

--- a/vocabularies/map.go
+++ b/vocabularies/map.go
@@ -109,6 +109,7 @@ var Map = map[string][]string{
 	"dataset_identifier_types": {
 		"DOI",
 		"BioStudies",
+		"EGA",
 		"ENA",
 		"ENABioProject",
 		"Ensembl",


### PR DESCRIPTION
fixes #1360 

Adds EGA identifier type

Notes:

* what is the `Validate` for if we never use it? e.g. an EGA identifier is probably only starting with EGA, not?
* does the `frontoffice.mapDataset` mapping require changes? I see that only DOI is taken out of the list of identifiers: https://github.com/ugent-library/biblio-backoffice/blob/main/frontoffice/record.go#L910. A change to this would however change all datasets (which is not much luckily).

