### PR TITLE
Devcontainer fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ Here are some useful commands to get you started:\n\
 Start the app:\n\
     reflex -d none -c reflex.docker.conf\n\
 \n\
-Purge all data from the database:\n\
+Purge all data from the database and initialize all tables/indexes:\n\
     go run main.go reset --force\n\
 \n\
 Happy hacking!\n"\

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ Start the app:\n\
     reflex -d none -c reflex.docker.conf\n\
 \n\
 Purge all data from the database:\n\
-    go run main.go reset --confirm\n\
+    go run main.go reset --force\n\
 \n\
 Happy hacking!\n"\
     > /etc/motd

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,14 +27,8 @@ Here are some useful commands to get you started:\n\
 Start the app:\n\
     reflex -d none -c reflex.docker.conf\n\
 \n\
-Seed the app with dummy data:\n\
-    go run main.go seed\n\
-\n\
-If you already have data in the database, you can force seeding:\n\
-    go run main.go seed --force\n\
-\n\
 Purge all data from the database:\n\
-    go run main.go reset --force\n\
+    go run main.go reset --confirm\n\
 \n\
 Happy hacking!\n"\
     > /etc/motd

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -87,7 +87,6 @@ services:
   db-app:
     image: postgres:16-alpine
     restart: unless-stopped
-    user: postgres
     volumes:
       - ../tmp/backoffice/db_data:/var/lib/postgresql/data
     environment:
@@ -104,7 +103,6 @@ services:
   db-people:
     image: postgres:16-alpine
     restart: unless-stopped
-    user: postgres
     volumes:
       - ../tmp/people/db_data:/var/lib/postgresql/data
     environment:
@@ -121,7 +119,6 @@ services:
   db-projects:
     image: postgres:16-alpine
     restart: unless-stopped
-    user: postgres
     volumes:
       - ../tmp/projects/db_data:/var/lib/postgresql/data
     environment:

--- a/cli/reset_cmd.go
+++ b/cli/reset_cmd.go
@@ -10,14 +10,15 @@ import (
 
 func init() {
 	rootCmd.AddCommand(resetCmd)
-	resetCmd.Flags().Bool("confirm", false, "destructive reset of all data")
+	resetCmd.Flags().Bool("force", false, "force destructive reset of all data")
 }
 
 var resetCmd = &cobra.Command{
 	Use:   "reset",
 	Short: "Destructive reset",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if confirm, _ := cmd.Flags().GetBool("confirm"); !confirm {
+		if force, _ := cmd.Flags().GetBool("force"); !force {
+			cmd.Println("The --force flag is required to perform a destructive reset.")
 			return nil
 		}
 


### PR DESCRIPTION
Added some minor changes for devcontainers:

* removed `user: postgres` from docker-compose.yml so that postgres can start up correctly, and does not try to set the user of the folder
* removed non existing example command for seeding from Dockerfile (misleading)