### PR TITLE
fix issue 1375

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
+	mvdan.cc/xurls/v2 v2.5.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1063,6 +1063,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+mvdan.cc/xurls/v2 v2.5.0 h1:lyBNOm8Wo71UknhUs4QTFUNNMyxy2JEIaKKo0RWOh+8=
+mvdan.cc/xurls/v2 v2.5.0/go.mod h1:yQgaGQ1rFtJUzkmKiHYSSfuQxqfYmd//X6PxvholpeE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/urls/funcmap.go
+++ b/urls/funcmap.go
@@ -94,8 +94,7 @@ func queryClear(u *url.URL) (*url.URL, error) {
 func renderMsg(oldVal string) template.HTML {
 	oldVal = html.EscapeString(oldVal)
 
-	oldVal = strings.ReplaceAll(oldVal, "\r\n", "\n")
-	oldVal = strings.ReplaceAll(oldVal, "\n", "<br>")
+	oldVal = strings.ReplaceAll(oldVal, "\r\n", "<br>")
 
 	re, _ := xurls.StrictMatchingScheme("https")
 	urlIndexPairs := re.FindAllStringIndex(oldVal, -1)
@@ -112,7 +111,7 @@ func renderMsg(oldVal string) template.HTML {
 		//URL
 		postfix := oldVal[pair[0]:pair[1]]
 		newValBuilder.WriteString("<a href=\"")
-		newValBuilder.WriteString(html.EscapeString(postfix))
+		newValBuilder.WriteString(postfix)
 		newValBuilder.WriteString("\" target=\"_blank\">")
 		newValBuilder.WriteString(postfix)
 		newValBuilder.WriteString("</a>")

--- a/urls/funcmap.go
+++ b/urls/funcmap.go
@@ -1,11 +1,14 @@
 package urls
 
 import (
+	"html"
 	"html/template"
 	"net/url"
+	"strings"
 
 	"github.com/go-playground/form/v4"
 	"github.com/nics/ich"
+	"mvdan.cc/xurls/v2"
 )
 
 var queryEncoder = form.NewEncoder()
@@ -25,6 +28,7 @@ func FuncMap(r *ich.Mux, scheme, host string) template.FuncMap {
 		"queryAdd":   queryAdd,
 		"queryDel":   queryDel,
 		"queryClear": queryClear,
+		"renderMsg":  renderMsg,
 	}
 }
 
@@ -85,4 +89,39 @@ func queryClear(u *url.URL) (*url.URL, error) {
 	newU.RawQuery = ""
 
 	return &newU, nil
+}
+
+func renderMsg(oldVal string) template.HTML {
+	oldVal = html.EscapeString(oldVal)
+
+	oldVal = strings.ReplaceAll(oldVal, "\r\n", "\n")
+	oldVal = strings.ReplaceAll(oldVal, "\n", "<br>")
+
+	re, _ := xurls.StrictMatchingScheme("https")
+	urlIndexPairs := re.FindAllStringIndex(oldVal, -1)
+
+	newValBuilder := strings.Builder{}
+	startPos := 0
+	for _, pair := range urlIndexPairs {
+		// NON URL
+		prefix := oldVal[startPos:pair[0]]
+		if len(prefix) > 0 {
+			newValBuilder.WriteString(prefix)
+		}
+
+		//URL
+		postfix := oldVal[pair[0]:pair[1]]
+		newValBuilder.WriteString("<a href=\"")
+		newValBuilder.WriteString(html.EscapeString(postfix))
+		newValBuilder.WriteString("\" target=\"_blank\">")
+		newValBuilder.WriteString(postfix)
+		newValBuilder.WriteString("</a>")
+		startPos = pair[1]
+	}
+	prefix := oldVal[startPos:]
+	if len(prefix) > 0 {
+		newValBuilder.WriteString(prefix)
+	}
+
+	return template.HTML(newValBuilder.String())
 }

--- a/views/dataset/_message_body.gohtml
+++ b/views/dataset/_message_body.gohtml
@@ -1,4 +1,4 @@
 <div class="card-body">
-    <p class="pb-3">{{.Dataset.Message}}</p>
+    <p class="pb-3">{{.Dataset.Message | renderMsg}}</p>
     <p class="text-muted">Have any questions or changes to report? Mail to <a href="mailto:rdm.support@ugent.be">rdm.support@ugent.be</a>.</p>
 </div>

--- a/views/dataset/search_hit.gohtml
+++ b/views/dataset/search_hit.gohtml
@@ -69,7 +69,7 @@
         <i class="if if-message"></i>
         <div class="alert-content">
             <h3 class="Biblio message">Biblio message</h3>
-            <p class="mt-2">{{.}}</p>
+            <p class="mt-2">{{. | renderMsg}}</p>
         </div>
     </div>
     {{end}}

--- a/views/publication/_message_body.gohtml
+++ b/views/publication/_message_body.gohtml
@@ -1,4 +1,4 @@
 <div class="card-body">
-    <p class="pb-3">{{.Publication.Message}}</p>
+    <p class="pb-3">{{.Publication.Message | renderMsg}}</p>
     <p class="text-muted">Have any questions or changes to report? Mail to <a href="mailto:biblio@ugent.be">biblio@ugent.be</a>.</p>
 </div>

--- a/views/publication/search_hit.gohtml
+++ b/views/publication/search_hit.gohtml
@@ -93,7 +93,7 @@
         <i class="if if-message"></i>
         <div class="alert-content">
             <h3 class="Biblio message">Biblio message</h3>
-            <p class="mt-2">{{.}}</p>
+            <p class="mt-2">{{. | renderMsg}}</p>
         </div>
     </div>
     {{end}}


### PR DESCRIPTION
fixes #1375 

how:

* added new func `renderMsg` to template funcmap that receives (unsafe) string and returns html safe string (template.HTML). Implemented as a filter.
* `renderMsg` does the following:
  * html escape input
  * replace newlines by `<br>`
  * replace all https links by `<a>`. Extracting urls was not trivial, as in all of the examples, the urls where hardly ever put between spaces, but mostly between parenthesises, before a dot, after a colon.. So I could not use something like "what is parseable as an url", as that required word extraction first. The limitation on https is due to the library that either allows for matching on a whole set of [schemes](https://pkg.go.dev/mvdan.cc/xurls/v2#Strict) (from http to file, which to much), or either one [scheme](https://pkg.go.dev/mvdan.cc/xurls/v2#StrictMatchingScheme). I think https is enough? Didn't feel the urge to search any further.