### PR TITLE
bug duplicate DOI for datasets in frontoffice record

### DIFF
--- a/frontoffice/record.go
+++ b/frontoffice/record.go
@@ -925,6 +925,10 @@ func MapDataset(d *models.Dataset, repo *repositories.Repo) *Record {
 	}
 
 	for typ, values := range d.Identifiers {
+		// already in attribute DOI
+		if typ == "DOI" {
+			continue
+		}
 		for _, value := range values {
 			rec.Identifier = append(rec.Identifier, Identifier{
 				Type:  typ,


### PR DESCRIPTION
Since the introduction of `frontoffice.Record#Identifier` for datasets, doi's are now present in both `frontoffice.Record#DOI` and `frontoffice.Record#Identifier`, leading to duplicate values in the record view. One should be taken away

Will require a reindexation of all datasets