### PR TITLE
export xlsx publication: fix field has_open_access_file

### DIFF
--- a/backends/excel/publication/publication_list_exporter.go
+++ b/backends/excel/publication/publication_list_exporter.go
@@ -5,13 +5,10 @@ import (
 	"io"
 	"strings"
 
-	"slices"
-
 	"github.com/ugent-library/biblio-backoffice/backends"
 	"github.com/ugent-library/biblio-backoffice/backends/excel"
 	"github.com/ugent-library/biblio-backoffice/models"
 	internal_time "github.com/ugent-library/biblio-backoffice/time"
-	"github.com/ugent-library/biblio-backoffice/vocabularies"
 )
 
 const sep = " ; "
@@ -222,7 +219,7 @@ func (x *xlsx) publicationToRow(pub *models.Publication) []string {
 	m["has_file"] = fmt.Sprintf("%t", len(pub.File) > 0)
 	m["has_open_access_file"] = "false"
 	for _, file := range pub.File {
-		if slices.Contains(vocabularies.Map["publication_file_access_levels"], file.AccessLevel) {
+		if file.AccessLevel == "info:eu-repo/semantics/openAccess" {
 			m["has_open_access_file"] = "true"
 			break
 		}


### PR DESCRIPTION
Field `has_open_access_file` in the XLSX export for publications is incorrectly always set to `true`
due to a condition that is always true. Fixed here.