### PR TITLE
Improve biblio issue 1380

### DIFF
--- a/api/v2/service.go
+++ b/api/v2/service.go
@@ -319,16 +319,19 @@ func convertProject(from *projects.Project) Project {
 }
 
 func convertOrganization(from *people.Organization) Organization {
-	return Organization{
+	o := Organization{
 		Identifiers: lo.Map(from.Identifiers, func(v people.Identifier, _ int) Identifier { return Identifier(v) }),
 		Names:       lo.Map(from.Names, func(v people.Text, _ int) Text { return Text(v) }),
 		Ceased:      from.Ceased,
-		CeasedOn:    lo.Ternary(from.CeasedOn != nil, NewOptDate(*from.CeasedOn), OptDate{Set: false}),
 		Position:    NewOptInt(from.Position),
 		Parents:     lo.Map(from.Parents, func(v people.ParentOrganization, _ int) ParentOrganization { return convertParentOrganization(v) }),
 		CreatedAt:   from.CreatedAt,
 		UpdatedAt:   from.UpdatedAt,
 	}
+	if from.CeasedOn != nil {
+		o.CeasedOn = NewOptDate(*from.CeasedOn)
+	}
+	return o
 }
 
 func convertPerson(from *people.Person) Person {

--- a/handlers/frontoffice/handler.go
+++ b/handlers/frontoffice/handler.go
@@ -158,8 +158,8 @@ func (h *Handler) GetPerson(w http.ResponseWriter, r *http.Request) {
 // TODO optimize
 func (h *Handler) GetPeople(w http.ResponseWriter, r *http.Request) {
 	ids := r.URL.Query()["id"]
-	recs := make([]*frontoffice.Person, len(ids))
-	for i, id := range ids {
+	recs := make([]*frontoffice.Person, 0, len(ids))
+	for _, id := range ids {
 		ident, err := people.NewIdentifier(id)
 		if err != nil {
 			render.InternalServerError(w, r, err)
@@ -168,14 +168,14 @@ func (h *Handler) GetPeople(w http.ResponseWriter, r *http.Request) {
 
 		p, err := h.PeopleIndex.GetPersonByIdentifier(r.Context(), ident.Kind, ident.Value)
 		if err == people.ErrNotFound {
-			render.NotFound(w, r, err)
-			return
+			h.Logger.Warnf("unable to find person with identifier %s", ident.String())
+			continue
 		}
 		if err != nil {
 			render.InternalServerError(w, r, err)
 			return
 		}
-		recs[i] = frontoffice.MapPerson(p)
+		recs = append(recs, frontoffice.MapPerson(p))
 	}
 
 	httpx.RenderJSON(w, 200, recs)

--- a/people/index.go
+++ b/people/index.go
@@ -377,6 +377,14 @@ func fixSortName(sort string) string {
 	return sort
 }
 
+func fixNameKey(nameKey string) string {
+	nameKey = strings.ReplaceAll(nameKey, "'", "")
+	nameKey = strings.TrimSpace(nameKey)
+	nameKey = strings.ToUpper(nameKey)
+	nameKey = nameKey[0:1]
+	return nameKey
+}
+
 func toPersonDoc(p *Person) (string, []byte, error) {
 	pd := &personDoc{
 		Names:       []string{p.Name},
@@ -385,11 +393,11 @@ func toPersonDoc(p *Person) (string, []byte, error) {
 	}
 
 	if p.FamilyName != "" {
-		pd.NameKey = p.FamilyName[0:1]
+		pd.NameKey = fixNameKey(p.FamilyName)
 		pd.SortName = p.FamilyName
 	}
 	if p.PreferredFamilyName != "" {
-		pd.NameKey = p.PreferredFamilyName[0:1]
+		pd.NameKey = fixNameKey(p.PreferredFamilyName)
 		pd.SortName = p.PreferredFamilyName
 	}
 	if p.GivenName != "" {

--- a/people/index.go
+++ b/people/index.go
@@ -369,6 +369,14 @@ type personDoc struct {
 	Record      *Person  `json:"record"`
 }
 
+func fixSortName(sort string) string {
+	sort = strings.ToLower(sort)
+	sort = strings.ReplaceAll(sort, " ", "")
+	sort = strings.ReplaceAll(sort, "'", "")
+	sort = strings.ReplaceAll(sort, "-", "")
+	return sort
+}
+
 func toPersonDoc(p *Person) (string, []byte, error) {
 	pd := &personDoc{
 		Names:       []string{p.Name},
@@ -389,6 +397,10 @@ func toPersonDoc(p *Person) (string, []byte, error) {
 	}
 	if p.PreferredGivenName != "" {
 		pd.SortName += p.PreferredGivenName
+	}
+
+	if pd.SortName != "" {
+		pd.SortName = fixSortName(pd.SortName)
 	}
 
 	for _, name := range []string{p.PreferredName, p.GivenName, p.PreferredGivenName, p.FamilyName, p.PreferredFamilyName} {

--- a/people/models.go
+++ b/people/models.go
@@ -226,7 +226,7 @@ type SearchParams struct {
 	Filters []SearchFilter `json:"filters"`
 	Limit   int            `json:"limit"`
 	Offset  int            `json:"offset"`
-	Sort    string         `json:"name"`
+	Sort    string         `json:"sort"`
 }
 
 func (p *SearchParams) AddFilter(str string) error {

--- a/people/organizations_index_settings.json
+++ b/people/organizations_index_settings.json
@@ -19,7 +19,7 @@
             },
             "token_edge_ngram": {
               "type": "edge_ngram",
-              "min_gram": "2",
+              "min_gram": "1",
               "max_gram": "20"
             }
           },
@@ -97,7 +97,11 @@
           },
           "identifiers": {
             "type": "keyword",
-            "normalizer": "tag"
+            "normalizer": "tag",
+            "copy_to": [
+              "ngram",
+              "phrase_ngram"
+            ]
           },
           "record": {
             "type": "object",

--- a/people/people_index_settings.json
+++ b/people/people_index_settings.json
@@ -19,7 +19,7 @@
             },
             "token_edge_ngram": {
               "type": "edge_ngram",
-              "min_gram": "2",
+              "min_gram": "1",
               "max_gram": "20"
             }
           },

--- a/projects/index.go
+++ b/projects/index.go
@@ -320,6 +320,14 @@ type projectDoc struct {
 	Record       *Project `json:"record"`
 }
 
+func fixSortName(sort string) string {
+	sort = strings.ToLower(sort)
+	sort = strings.ReplaceAll(sort, " ", "")
+	sort = strings.ReplaceAll(sort, "'", "")
+	sort = strings.ReplaceAll(sort, "-", "")
+	return sort
+}
+
 func toProjectDoc(p *Project) (string, []byte, error) {
 	pd := &projectDoc{
 		Names:        make([]string, len(p.Names)),
@@ -332,6 +340,10 @@ func toProjectDoc(p *Project) (string, []byte, error) {
 	if name := p.Names.Get("und"); name != "" {
 		pd.SortName = name
 		pd.NameKey = name[0:1]
+	}
+
+	if pd.SortName != "" {
+		pd.SortName = fixSortName(pd.SortName)
 	}
 
 	for i, name := range p.Names {

--- a/projects/index.go
+++ b/projects/index.go
@@ -114,6 +114,15 @@ const queryStringQuery = `{{define "query"}}{
 			},
 			{
 				"match": {
+					"all": {
+						"query": "{{.Query}}",
+						"operator": "AND",
+						"boost": "0.1"
+					}
+				}
+			},
+			{
+				"match": {
 					"phrase_ngram": {
 						"query": "{{.Query}}",
 						"operator": "AND",

--- a/projects/projects_index_settings.json
+++ b/projects/projects_index_settings.json
@@ -88,6 +88,9 @@
       "project": {
         "dynamic": "false",
         "properties": {
+          "all": {
+            "type": "text"
+          },
           "nameKey": {
             "type": "keyword",
             "normalizer": "tag"
@@ -99,6 +102,7 @@
           "names": {
             "type": "text",
             "copy_to": [
+              "all",
               "ngram",
               "phrase_ngram"
             ]
@@ -106,6 +110,7 @@
           "descriptions": {
             "type": "text",
             "copy_to": [
+              "all",
               "ngram",
               "phrase_ngram"
             ]


### PR DESCRIPTION
Done:

* make person suggest work (one lettered input returned nothing)
* make organization suggest work (one lettered input returned nothing)
* make project suggest work (one lettered input returned nothing)
* `/frontoffice/person/list` incorrectly returns 404 when one provided id is not found. ID's that are not found should be removed from the list? The frontend converts the result into a map anyway to display facets, and what it does not have, is not used. Before some person/organization pages with publication lists crashed before this.
* filter `sortName` on certain characters, and lower case