### PR TITLE
further remove wrapped handler functionality from mediatypes handler

### DIFF
--- a/handlers/mediatypes/handler.go
+++ b/handlers/mediatypes/handler.go
@@ -3,19 +3,11 @@ package mediatypes
 import (
 	"net/http"
 
-	"github.com/ugent-library/biblio-backoffice/backends"
 	"github.com/ugent-library/biblio-backoffice/ctx"
-	"github.com/ugent-library/biblio-backoffice/handlers"
-	"github.com/ugent-library/biblio-backoffice/render"
 	"github.com/ugent-library/biblio-backoffice/views/media_types"
 )
 
-type Handler struct {
-	handlers.BaseHandler
-	MediaTypeSearchService backends.MediaTypeSearchService
-}
-
-func (h *Handler) Suggest(w http.ResponseWriter, r *http.Request) {
+func Suggest(w http.ResponseWriter, r *http.Request) {
 	c := ctx.Get(r)
 
 	// TODO how can we change a param name with htmx?
@@ -25,10 +17,10 @@ func (h *Handler) Suggest(w http.ResponseWriter, r *http.Request) {
 	}
 	query := r.URL.Query().Get(input)
 
-	hits, err := h.MediaTypeSearchService.SuggestMediaTypes(query)
+	hits, err := c.Services.MediaTypeSearchService.SuggestMediaTypes(query)
 	if err != nil {
-		h.Logger.Errorw("suggest mediatype: could not suggest mediatypes:", "errors", err, "query", query, "user", c.User.ID)
-		render.InternalServerError(w, r, err)
+		c.Log.Errorw("suggest mediatype: could not suggest mediatypes:", "errors", err, "query", query, "user", c.User.ID)
+		c.HandleError(w, r, err)
 		return
 	}
 

--- a/routes/register.go
+++ b/routes/register.go
@@ -216,11 +216,6 @@ func Register(c Config) {
 		Repo:        c.Services.Repo,
 	}
 
-	mediaTypesHandler := &mediatypes.Handler{
-		BaseHandler:            baseHandler,
-		MediaTypeSearchService: c.Services.MediaTypeSearchService,
-	}
-
 	// frontoffice data exchange api
 	c.Router.Group(func(r *ich.Mux) {
 		r.Use(httpx.BasicAuth(c.FrontendUsername, c.FrontendPassword))
@@ -377,7 +372,7 @@ func Register(c Config) {
 				})
 
 				// media types
-				r.Get("/media_type/suggestions", mediaTypesHandler.Suggest).Name("suggest_media_types")
+				r.Get("/media_type/suggestions", mediatypes.Suggest).Name("suggest_media_types")
 			})
 		})
 		// END NEW STYLE HANDLERS


### PR DESCRIPTION
The removal of the Wrap method and conversion from gohtml to templ was already done by @verheyenkoen in 7f34da08217bbc5f48194f0bc6a14268a5ad8b87

I now replaced the wrapped handler functionality by the new setup