### PR TITLE
Various small changes to already merged refactor-to-templ PR's #1402

### DIFF
--- a/handlers/datasetediting/contributors.go
+++ b/handlers/datasetediting/contributors.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ugent-library/biblio-backoffice/snapstore"
 	"github.com/ugent-library/biblio-backoffice/views/dataset"
 	"github.com/ugent-library/bind"
+	"github.com/ugent-library/httperror"
 	"github.com/ugent-library/okay"
 )
 
@@ -143,12 +144,6 @@ type YieldConfirmUpdateContributor struct {
 	Active      bool
 	Form        *form.Form
 	EditNext    bool
-}
-
-type YieldDeleteContributor struct {
-	Context
-	Role     string
-	Position int
 }
 
 func (h *Handler) AddContributor(w http.ResponseWriter, r *http.Request, ctx Context) {
@@ -592,13 +587,13 @@ func (h *Handler) UpdateContributor(w http.ResponseWriter, r *http.Request, ctx 
 	})
 }
 
-func (h *Handler) ConfirmDeleteContributor(w http.ResponseWriter, r *http.Request) {
+func ConfirmDeleteContributor(w http.ResponseWriter, r *http.Request) {
 	c := ctx.Get(r)
 
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
-		h.Logger.Warnw("confirm delete dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		render.BadRequest(w, r, err)
+		c.Log.Warnw("confirm delete dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
+		c.HandleError(w, r, httperror.BadRequest)
 		return
 	}
 

--- a/handlers/datasetediting/delete.go
+++ b/handlers/datasetediting/delete.go
@@ -8,38 +8,32 @@ import (
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
 	"github.com/ugent-library/biblio-backoffice/handlers"
-	"github.com/ugent-library/biblio-backoffice/models"
 	"github.com/ugent-library/biblio-backoffice/render"
 	"github.com/ugent-library/biblio-backoffice/render/flash"
 	"github.com/ugent-library/biblio-backoffice/snapstore"
 	"github.com/ugent-library/biblio-backoffice/views/dataset"
+	"github.com/ugent-library/httperror"
 )
 
-type YieldConfirmDelete struct {
-	Context
-	Dataset     *models.Dataset
-	RedirectURL string
-}
-
-func (h *Handler) ConfirmDelete(w http.ResponseWriter, r *http.Request) {
+func ConfirmDelete(w http.ResponseWriter, r *http.Request) {
 	c := ctx.Get(r)
 
 	dataset.ConfirmDelete(c, ctx.GetDataset(r), r.URL.Query().Get("redirect-url")).Render(r.Context(), w)
 }
 
-func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+func Delete(w http.ResponseWriter, r *http.Request) {
 	c := ctx.Get(r)
 	dataset := ctx.GetDataset(r)
 
 	if !c.User.CanDeleteDataset(dataset) {
-		h.Logger.Warnw("delete dataset: user isn't allowed to delete dataset", "dataset", dataset.ID, "user", c.User.ID, "user", c.User.ID)
-		render.Forbidden(w, r)
+		c.Log.Warnw("delete dataset: user isn't allowed to delete dataset", "dataset", dataset.ID, "user", c.User.ID, "user", c.User.ID)
+		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
 
 	dataset.Status = "deleted"
 
-	err := h.Repo.UpdateDataset(r.Header.Get("If-Match"), dataset, c.User)
+	err := c.Repo.UpdateDataset(r.Header.Get("If-Match"), dataset, c.User)
 
 	var conflict *snapstore.Conflict
 	if errors.As(err, &conflict) {
@@ -51,8 +45,8 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		h.Logger.Errorf("delete dataset: Could not save the dataset:", "error", err, "identifier", dataset.ID, "user", c.User.ID)
-		render.InternalServerError(w, r, err)
+		c.Log.Errorf("delete dataset: Could not save the dataset:", "error", err, "identifier", dataset.ID, "user", c.User.ID)
+		c.HandleError(w, r, httperror.InternalServerError)
 		return
 	}
 
@@ -60,7 +54,7 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 		WithLevel("success").
 		WithBody(template.HTML("<p>Dataset was successfully deleted.</p>"))
 
-	h.AddFlash(r, w, *flash)
+	c.PersistFlash(w, *flash)
 
 	// TODO temporary fix until we can figure out a way let ES notify this handler that it did its thing.
 	// see: https://github.com/ugent-library/biblio-backoffice/issues/590

--- a/routes/register.go
+++ b/routes/register.go
@@ -363,8 +363,8 @@ func Register(c Config) {
 					r.Use(ctx.SetDataset(c.Services.Repo))
 
 					// delete
-					r.Get("/confirm-delete", datasetEditingHandler.ConfirmDelete).Name("dataset_confirm_delete")
-					r.Delete("/", datasetEditingHandler.Delete).Name("dataset_delete")
+					r.Get("/confirm-delete", datasetediting.ConfirmDelete).Name("dataset_confirm_delete")
+					r.Delete("/", datasetediting.Delete).Name("dataset_delete")
 
 					// publish
 					r.Get("/publish/confirm", datasetEditingHandler.ConfirmPublish).Name("dataset_confirm_publish")

--- a/routes/register.go
+++ b/routes/register.go
@@ -367,8 +367,8 @@ func Register(c Config) {
 					r.Delete("/", datasetediting.Delete).Name("dataset_delete")
 
 					// publish
-					r.Get("/publish/confirm", datasetEditingHandler.ConfirmPublish).Name("dataset_confirm_publish")
-					r.Post("/publish", datasetEditingHandler.Publish).Name("dataset_publish")
+					r.Get("/publish/confirm", datasetediting.ConfirmPublish).Name("dataset_confirm_publish")
+					r.Post("/publish", datasetediting.Publish).Name("dataset_publish")
 
 					// withdraw
 					r.Get("/withdraw/confirm", datasetEditingHandler.ConfirmWithdraw).Name("dataset_confirm_withdraw")

--- a/routes/register.go
+++ b/routes/register.go
@@ -379,7 +379,7 @@ func Register(c Config) {
 					r.Post("/republish", datasetEditingHandler.Republish).Name("dataset_republish")
 
 					// contributor actions
-					r.Get("/contributors/{role}/{position}/confirm-delete", datasetEditingHandler.ConfirmDeleteContributor).Name("dataset_confirm_delete_contributor")
+					r.Get("/contributors/{role}/{position}/confirm-delete", datasetediting.ConfirmDeleteContributor).Name("dataset_confirm_delete_contributor")
 
 					// curator actions
 					r.Group(func(r *ich.Mux) {


### PR DESCRIPTION
These changes include:

* Converting handler methods to regular functions
* Refactor error handling (`c.HandleError` instead of `render.BadRequest`/`render.Forbidden`/`render.InternalServerError`/...)