### PR TITLE
Plato basic auth

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -63,6 +63,11 @@ type Config struct {
 		ClientSecret string `env:"CLIENT_SECRET"`
 		Sandbox      bool   `env:"SANDBOX"`
 	} `envPrefix:"ORCID_"`
+	Plato struct {
+		URL      string `env:"URL"`
+		Username string `env:"USERNAME"`
+		Password string `env:"PASSWORD"`
+	} `envPrefix:"PLATO_"`
 	OIDC struct {
 		URL           string `env:"URL"`
 		ClientID      string `env:"CLIENT_ID"`

--- a/cli/config.go
+++ b/cli/config.go
@@ -63,11 +63,6 @@ type Config struct {
 		ClientSecret string `env:"CLIENT_SECRET"`
 		Sandbox      bool   `env:"SANDBOX"`
 	} `envPrefix:"ORCID_"`
-	Plato struct {
-		URL      string `env:"URL"`
-		Username string `env:"USERNAME"`
-		Password string `env:"PASSWORD"`
-	} `envPrefix:"PLATO_"`
 	OIDC struct {
 		URL           string `env:"URL"`
 		ClientID      string `env:"CLIENT_ID"`

--- a/cli/update_candidate_records_cmd.go
+++ b/cli/update_candidate_records_cmd.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ugent-library/biblio-backoffice/models"
 	"github.com/ugent-library/biblio-backoffice/recordsources"
-	"github.com/ugent-library/biblio-backoffice/recordsources/plato"
+	_ "github.com/ugent-library/biblio-backoffice/recordsources/plato"
 )
 
 func init() {
@@ -21,11 +21,7 @@ var updateCandidateRecords = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		services := newServices()
 
-		src, err := recordsources.New("plato", plato.Config{
-			Url:      config.Plato.URL,
-			Username: config.Plato.Username,
-			Password: config.Plato.Password,
-		})
+		src, err := recordsources.New("plato")
 		if err != nil {
 			return err
 		}

--- a/cli/update_candidate_records_cmd.go
+++ b/cli/update_candidate_records_cmd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ugent-library/biblio-backoffice/recordsources"
-	_ "github.com/ugent-library/biblio-backoffice/recordsources/plato"
+	"github.com/ugent-library/biblio-backoffice/recordsources/plato"
 )
 
 func init() {
@@ -19,7 +19,11 @@ var updateCandidateRecords = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		services := newServices()
 
-		src, err := recordsources.New("plato", "https://plato.ea.ugent.be/service/dr/2biblio.jsp")
+		src, err := recordsources.New("plato", plato.Config{
+			Url:      config.Plato.URL,
+			Username: config.Plato.Username,
+			Password: config.Plato.Password,
+		})
 		if err != nil {
 			return err
 		}

--- a/recordsources/plato/source.go
+++ b/recordsources/plato/source.go
@@ -16,14 +16,25 @@ func init() {
 	recordsources.Register("plato", NewSource)
 }
 
-func NewSource(conn string) (recordsources.Source, error) {
+type Config struct {
+	Url      string
+	Username string
+	Password string
+}
+
+func NewSource(config any) (recordsources.Source, error) {
+	c := config.(Config)
 	return &platoSource{
-		url: conn,
+		url:      c.Url,
+		username: c.Username,
+		password: c.Password,
 	}, nil
 }
 
 type platoSource struct {
-	url string
+	url      string
+	username string
+	password string
 }
 
 func (s *platoSource) GetRecords(ctx context.Context, cb func(recordsources.Record) error) error {
@@ -50,12 +61,42 @@ func (s *platoSource) GetRecords(ctx context.Context, cb func(recordsources.Reco
 		if err != nil {
 			return err
 		}
+
+		req.SetBasicAuth(s.username, s.password)
+
 		res, err := c.Do(req)
 		if err != nil {
 			return err
 		}
 		body, err := io.ReadAll(res.Body)
 		if err != nil {
+			return err
+		}
+
+		statusOK := res.StatusCode >= http.StatusOK && res.StatusCode <= http.StatusPermanentRedirect
+		if !statusOK {
+			var err error
+			switch res.StatusCode {
+			// 4xx
+			case http.StatusBadRequest:
+				err = fmt.Errorf("[plato] a bad http request was sent to the server: %s", res.Status)
+			case http.StatusUnauthorized:
+				err = fmt.Errorf("[plato] the client wasn't authorized by the server, check credentials: %s", res.Status)
+			case http.StatusNotFound:
+				err = fmt.Errorf("[plato] the API endpoint URL could not be found: %s", res.Status)
+			case http.StatusForbidden:
+				err = fmt.Errorf("[plato] authorized but access forbidden: %s", res.Status)
+			// 5xx
+			case http.StatusInternalServerError:
+				err = fmt.Errorf("[plato] internal server error: %s", res.Status)
+			case http.StatusBadGateway:
+				err = fmt.Errorf("[plato] bad gateway error: %s", res.Status)
+			case http.StatusServiceUnavailable:
+				err = fmt.Errorf("[plato] service unavailable error: %s", res.Status)
+			default:
+				err = fmt.Errorf("[plato] server returned an error: %s", res.Status)
+			}
+
 			return err
 		}
 

--- a/recordsources/plato/source.go
+++ b/recordsources/plato/source.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/caarlos0/env/v10"
 	"github.com/tidwall/gjson"
 	"github.com/ugent-library/biblio-backoffice/recordsources"
 )
@@ -17,17 +18,23 @@ func init() {
 }
 
 type Config struct {
-	Url      string
-	Username string
-	Password string
+	Plato struct {
+		URL      string `env:"URL"`
+		Username string `env:"USERNAME"`
+		Password string `env:"PASSWORD"`
+	} `envPrefix:"PLATO_"`
 }
 
-func NewSource(config any) (recordsources.Source, error) {
-	c := config.(Config)
+func NewSource() (recordsources.Source, error) {
+	c := &Config{}
+	env.ParseWithOptions(c, env.Options{
+		Prefix: "BIBLIO_BACKOFFICE_",
+	})
+
 	return &platoSource{
-		url:      c.Url,
-		username: c.Username,
-		password: c.Password,
+		url:      c.Plato.URL,
+		username: c.Plato.Username,
+		password: c.Plato.Password,
 	}, nil
 }
 

--- a/recordsources/source.go
+++ b/recordsources/source.go
@@ -19,7 +19,7 @@ type Record interface {
 	ToCandidateRecord(*backends.Services) (*models.CandidateRecord, error)
 }
 
-type Factory func(any) (Source, error)
+type Factory func() (Source, error)
 
 var factories = make(map[string]Factory)
 var mu sync.RWMutex
@@ -30,12 +30,12 @@ func Register(name string, factory Factory) {
 	factories[name] = factory
 }
 
-func New(name string, config any) (Source, error) {
+func New(name string) (Source, error) {
 	mu.RLock()
 	factory, ok := factories[name]
 	mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("unknown source '%s'", name)
 	}
-	return factory(config)
+	return factory()
 }

--- a/recordsources/source.go
+++ b/recordsources/source.go
@@ -19,7 +19,7 @@ type Record interface {
 	ToCandidateRecord(*backends.Services) (*models.CandidateRecord, error)
 }
 
-type Factory func(string) (Source, error)
+type Factory func(any) (Source, error)
 
 var factories = make(map[string]Factory)
 var mu sync.RWMutex
@@ -30,12 +30,12 @@ func Register(name string, factory Factory) {
 	factories[name] = factory
 }
 
-func New(name, conn string) (Source, error) {
+func New(name string, config any) (Source, error) {
 	mu.RLock()
 	factory, ok := factories[name]
 	mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("unknown source '%s'", name)
 	}
-	return factory(conn)
+	return factory(config)
 }

--- a/repositories/candidate_records.go
+++ b/repositories/candidate_records.go
@@ -11,8 +11,9 @@ import (
 )
 
 func (r *Repo) AddCandidateRecord(ctx context.Context, rec *models.CandidateRecord) error {
+	rec.ID = ulid.Make().String()
 	params := db.AddCandidateRecordParams{
-		ID:             ulid.Make().String(),
+		ID:             rec.ID,
 		SourceName:     rec.SourceName,
 		SourceID:       rec.SourceID,
 		SourceMetadata: rec.SourceMetadata,


### PR DESCRIPTION
* Store candidate record store connection settings in .env / config.
* Fixes skip duplicate candidate records check.
* Checks for API endpoint http 4xx & 5xx errors