### PR TITLE
Added URLBuilder for constructing outgoing url's

### DIFF
--- a/views/pagination.templ
+++ b/views/pagination.templ
@@ -9,7 +9,7 @@ templ Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, se
 	<ul class="pagination">
 		if searchHits.HasPreviousPage() {
 			<li class="page-item">
-				<a class="page-link" href={ URL(baseURL).WithQuery(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL() } aria-label="Previous">
+				<a class="page-link" href={ URL(baseURL).Query(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL() } aria-label="Previous">
 					<i class="if if-chevron-left" aria-hidden="true"></i>
 				</a>
 			</li>
@@ -23,7 +23,7 @@ templ Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, se
 		for _, page := range searchHits.PagesWithEllipsis() {
 			if page > 0 {
 				<li class={ "page-item", templ.KV("active", searchHits.Page() == page) }>
-					<a class="page-link" href={ URL(baseURL).WithQuery(searchArgs.Clone().WithPage(page)).SafeURL() } aria-label={ fmt.Sprintf("Page %d", page) }>
+					<a class="page-link" href={ URL(baseURL).Query(searchArgs.Clone().WithPage(page)).SafeURL() } aria-label={ fmt.Sprintf("Page %d", page) }>
 						{ fmt.Sprintf("%d", page) }
 					</a>
 				</li>
@@ -37,7 +37,7 @@ templ Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, se
 		}
 		if searchHits.HasNextPage() {
 			<li class="page-item">
-				<a class="page-link" href={ URL(baseURL).WithQuery(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL() } aria-label="Next">
+				<a class="page-link" href={ URL(baseURL).Query(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL() } aria-label="Next">
 					<i class="if if-chevron-right" aria-hidden="true"></i>
 				</a>
 			</li>

--- a/views/pagination.templ
+++ b/views/pagination.templ
@@ -6,49 +6,49 @@ import "github.com/ugent-library/biblio-backoffice/ctx"
 import "github.com/ugent-library/biblio-backoffice/models"
 
 templ Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, searchHits *models.SearchHits) {
-    <ul class="pagination">
-    if searchHits.HasPreviousPage() {
-        <li class="page-item">
-            <a class="page-link" href={templ.URL(urlWithQuery(baseURL, searchArgs.Clone().WithPage(searchHits.PreviousPage())).String())} aria-label="Previous">
-                <i class="if if-chevron-left" aria-hidden="true"></i>
-            </a>
-        </li>
-    } else {
-        <li class="page-item disabled">
-            <a class="page-link" href="#" aria-label="Previous">
-                <i class="if if-chevron-left" aria-hidden="true"></i>
-            </a>
-        </li>
-    }
-    for _, page := range searchHits.PagesWithEllipsis() {
-        if page > 0 {
-            <li class={ "page-item", templ.KV("active", searchHits.Page() == page) }>
-                <a class="page-link" href={templ.URL(urlWithQuery(baseURL, searchArgs.Clone().WithPage(page)).String())} aria-label={fmt.Sprintf("Page %d", page)}>
-                    {fmt.Sprintf("%d", page)}
-                </a>
-            </li>
-        } else {
-            <li class="page-item disabled">
-                <a class="page-link" href="#">
-                    &hellip;
-                </a>
-            </li>
-        }
-    }
-    if searchHits.HasNextPage() {
-        <li class="page-item">
-            <a class="page-link" href={templ.URL(urlWithQuery(baseURL, searchArgs.Clone().WithPage(searchHits.NextPage())).String())} aria-label="Next">
-                <i class="if if-chevron-right" aria-hidden="true"></i>
-            </a>
-        </li>
-    } else {
-        <li class="page-item disabled">
-            <a class="page-link" href="#" aria-label="Next">
-                <i class="if if-chevron-right" aria-hidden="true"></i>
-            </a>
-        </li>
-    }
-    </ul>    
+	<ul class="pagination">
+		if searchHits.HasPreviousPage() {
+			<li class="page-item">
+				<a class="page-link" href={ NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL() } aria-label="Previous">
+					<i class="if if-chevron-left" aria-hidden="true"></i>
+				</a>
+			</li>
+		} else {
+			<li class="page-item disabled">
+				<a class="page-link" href="#" aria-label="Previous">
+					<i class="if if-chevron-left" aria-hidden="true"></i>
+				</a>
+			</li>
+		}
+		for _, page := range searchHits.PagesWithEllipsis() {
+			if page > 0 {
+				<li class={ "page-item", templ.KV("active", searchHits.Page() == page) }>
+					<a class="page-link" href={ NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(page)).SafeURL() } aria-label={ fmt.Sprintf("Page %d", page) }>
+						{ fmt.Sprintf("%d", page) }
+					</a>
+				</li>
+			} else {
+				<li class="page-item disabled">
+					<a class="page-link" href="#">
+						&hellip;
+					</a>
+				</li>
+			}
+		}
+		if searchHits.HasNextPage() {
+			<li class="page-item">
+				<a class="page-link" href={ NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL() } aria-label="Next">
+					<i class="if if-chevron-right" aria-hidden="true"></i>
+				</a>
+			</li>
+		} else {
+			<li class="page-item disabled">
+				<a class="page-link" href="#" aria-label="Next">
+					<i class="if if-chevron-right" aria-hidden="true"></i>
+				</a>
+			</li>
+		}
+	</ul>
 }
 
 func PaginationCount(c *ctx.Ctx, searchHits *models.SearchHits) string {

--- a/views/pagination.templ
+++ b/views/pagination.templ
@@ -9,7 +9,7 @@ templ Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, se
 	<ul class="pagination">
 		if searchHits.HasPreviousPage() {
 			<li class="page-item">
-				<a class="page-link" href={ NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL() } aria-label="Previous">
+				<a class="page-link" href={ URL(baseURL).WithQuery(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL() } aria-label="Previous">
 					<i class="if if-chevron-left" aria-hidden="true"></i>
 				</a>
 			</li>
@@ -23,7 +23,7 @@ templ Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, se
 		for _, page := range searchHits.PagesWithEllipsis() {
 			if page > 0 {
 				<li class={ "page-item", templ.KV("active", searchHits.Page() == page) }>
-					<a class="page-link" href={ NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(page)).SafeURL() } aria-label={ fmt.Sprintf("Page %d", page) }>
+					<a class="page-link" href={ URL(baseURL).WithQuery(searchArgs.Clone().WithPage(page)).SafeURL() } aria-label={ fmt.Sprintf("Page %d", page) }>
 						{ fmt.Sprintf("%d", page) }
 					</a>
 				</li>
@@ -37,7 +37,7 @@ templ Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, se
 		}
 		if searchHits.HasNextPage() {
 			<li class="page-item">
-				<a class="page-link" href={ NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL() } aria-label="Next">
+				<a class="page-link" href={ URL(baseURL).WithQuery(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL() } aria-label="Next">
 					<i class="if if-chevron-right" aria-hidden="true"></i>
 				</a>
 			</li>

--- a/views/pagination_templ.go
+++ b/views/pagination_templ.go
@@ -37,7 +37,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var2 templ.SafeURL = templ.URL(urlWithQuery(baseURL, searchArgs.Clone().WithPage(searchHits.PreviousPage())).String())
+			var templ_7745c5c3_Var2 templ.SafeURL = NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL()
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var2)))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -71,7 +71,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var4 templ.SafeURL = templ.URL(urlWithQuery(baseURL, searchArgs.Clone().WithPage(page)).String())
+				var templ_7745c5c3_Var4 templ.SafeURL = NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(page)).SafeURL()
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var4)))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -91,7 +91,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 				var templ_7745c5c3_Var5 string
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", page))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pagination.templ`, Line: 26, Col: 44}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pagination.templ`, Line: 26, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
@@ -113,7 +113,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 templ.SafeURL = templ.URL(urlWithQuery(baseURL, searchArgs.Clone().WithPage(searchHits.NextPage())).String())
+			var templ_7745c5c3_Var6 templ.SafeURL = NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL()
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var6)))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err

--- a/views/pagination_templ.go
+++ b/views/pagination_templ.go
@@ -37,7 +37,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var2 templ.SafeURL = URL(baseURL).WithQuery(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL()
+			var templ_7745c5c3_Var2 templ.SafeURL = URL(baseURL).Query(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL()
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var2)))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -71,7 +71,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var4 templ.SafeURL = URL(baseURL).WithQuery(searchArgs.Clone().WithPage(page)).SafeURL()
+				var templ_7745c5c3_Var4 templ.SafeURL = URL(baseURL).Query(searchArgs.Clone().WithPage(page)).SafeURL()
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var4)))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -113,7 +113,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 templ.SafeURL = URL(baseURL).WithQuery(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL()
+			var templ_7745c5c3_Var6 templ.SafeURL = URL(baseURL).Query(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL()
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var6)))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err

--- a/views/pagination_templ.go
+++ b/views/pagination_templ.go
@@ -37,7 +37,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var2 templ.SafeURL = NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL()
+			var templ_7745c5c3_Var2 templ.SafeURL = URL(baseURL).WithQuery(searchArgs.Clone().WithPage(searchHits.PreviousPage())).SafeURL()
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var2)))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -71,7 +71,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var4 templ.SafeURL = NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(page)).SafeURL()
+				var templ_7745c5c3_Var4 templ.SafeURL = URL(baseURL).WithQuery(searchArgs.Clone().WithPage(page)).SafeURL()
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var4)))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -113,7 +113,7 @@ func Pagination(c *ctx.Ctx, baseURL *url.URL, searchArgs *models.SearchArgs, sea
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 templ.SafeURL = NewURLBuilder(baseURL.String()).WithQuery(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL()
+			var templ_7745c5c3_Var6 templ.SafeURL = URL(baseURL).WithQuery(searchArgs.Clone().WithPage(searchHits.NextPage())).SafeURL()
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var6)))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err

--- a/views/urls.go
+++ b/views/urls.go
@@ -15,13 +15,13 @@ func URL(base *url.URL) *URLBuilder {
 	return &URLBuilder{base}
 }
 
-func (builder *URLBuilder) WithPath(path ...string) *URLBuilder {
+func (builder *URLBuilder) Path(path ...string) *URLBuilder {
 	builder.url = builder.url.JoinPath(path...)
 
 	return builder
 }
 
-func (builder *URLBuilder) AddQuery(key string, value string) *URLBuilder {
+func (builder *URLBuilder) AddQueryParam(key string, value string) *URLBuilder {
 	query := builder.url.Query()
 	query.Add(key, value)
 
@@ -30,7 +30,7 @@ func (builder *URLBuilder) AddQuery(key string, value string) *URLBuilder {
 	return builder
 }
 
-func (builder *URLBuilder) WithQuery(query any) *URLBuilder {
+func (builder *URLBuilder) Query(query any) *URLBuilder {
 	vals, err := bind.EncodeQuery(query)
 	if err != nil {
 		return builder

--- a/views/urls.go
+++ b/views/urls.go
@@ -11,14 +11,8 @@ type URLBuilder struct {
 	url *url.URL
 }
 
-func NewURLBuilder(base string) *URLBuilder {
-	url, err := url.Parse(base)
-	if err != nil {
-		// TODO: how to deal with this
-		panic(err)
-	}
-
-	return &URLBuilder{url}
+func URL(base *url.URL) *URLBuilder {
+	return &URLBuilder{base}
 }
 
 func (builder *URLBuilder) WithPath(path ...string) *URLBuilder {

--- a/views/urls.go
+++ b/views/urls.go
@@ -3,15 +3,63 @@ package views
 import (
 	"net/url"
 
+	"github.com/a-h/templ"
 	"github.com/ugent-library/bind"
 )
 
-func urlWithQuery(u *url.URL, v any) *url.URL {
-	vals, err := bind.EncodeQuery(v)
+type URLBuilder struct {
+	url *url.URL
+}
+
+func NewURLBuilder(base string) *URLBuilder {
+	url, err := url.Parse(base)
 	if err != nil {
-		return u
+		// TODO: how to deal with this
+		panic(err)
 	}
-	newU := *u
-	newU.RawQuery = vals.Encode()
-	return &newU
+
+	return &URLBuilder{url}
+}
+
+func (builder *URLBuilder) WithPath(path ...string) *URLBuilder {
+	builder.url = builder.url.JoinPath(path...)
+
+	return builder
+}
+
+func (builder *URLBuilder) AddQuery(key string, value string) *URLBuilder {
+	query := builder.url.Query()
+	query.Add(key, value)
+
+	builder.url.RawQuery = query.Encode()
+
+	return builder
+}
+
+func (builder *URLBuilder) WithQuery(query any) *URLBuilder {
+	vals, err := bind.EncodeQuery(query)
+	if err != nil {
+		return builder
+	}
+
+	builder.url.RawQuery = vals.Encode()
+	return builder
+}
+
+func (builder *URLBuilder) ClearQuery() *URLBuilder {
+	builder.url.RawQuery = ""
+
+	return builder
+}
+
+func (builder *URLBuilder) URL() *url.URL {
+	return builder.url
+}
+
+func (builder *URLBuilder) String() string {
+	return builder.url.String()
+}
+
+func (builder *URLBuilder) SafeURL() templ.SafeURL {
+	return templ.URL(builder.String())
 }

--- a/views/urls.go
+++ b/views/urls.go
@@ -30,13 +30,18 @@ func (builder *URLBuilder) AddQueryParam(key string, value string) *URLBuilder {
 	return builder
 }
 
-func (builder *URLBuilder) Query(query any) *URLBuilder {
-	vals, err := bind.EncodeQuery(query)
-	if err != nil {
-		return builder
+func (builder *URLBuilder) Query(query interface{}) *URLBuilder {
+	if str, ok := query.(string); ok {
+		builder.url.RawQuery = str
+	} else {
+		vals, err := bind.EncodeQuery(query)
+		if err != nil {
+			return builder
+		}
+
+		builder.url.RawQuery = vals.Encode()
 	}
 
-	builder.url.RawQuery = vals.Encode()
 	return builder
 }
 

--- a/views/urls_test.go
+++ b/views/urls_test.go
@@ -8,26 +8,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWithPath(t *testing.T) {
+func TestPath(t *testing.T) {
 	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment"))
 
-	u.WithPath("foo", "123", "bar/", "456", "/baz", "789")
+	u.Path("foo", "123", "bar/", "456", "/baz", "789")
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/foo/123/bar/456/baz/789?query=string#fragment", u)
 }
 
-func TestAddQuery(t *testing.T) {
+func TestAddQueryParam(t *testing.T) {
 	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment"))
 
-	u.AddQuery("foo", "123")
+	u.AddQueryParam("foo", "123")
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?foo=123&query=string#fragment", u) // query params are added in alphabetical order
 
-	u.AddQuery("bar", "456")
+	u.AddQueryParam("bar", "456")
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?bar=456&foo=123&query=string#fragment", u)
 
-	u.AddQuery("baz", "789")
+	u.AddQueryParam("baz", "789")
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?bar=456&baz=789&foo=123&query=string#fragment", u)
 
-	u.AddQuery("bar", "123")
+	u.AddQueryParam("bar", "123")
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?bar=456&bar=123&baz=789&foo=123&query=string#fragment", u)
 }
 
@@ -37,22 +37,22 @@ type queryType struct {
 	Limit   int    `query:"limit,omitempty"`
 }
 
-func TestWithQuery(t *testing.T) {
+func TestQuery(t *testing.T) {
 	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment"))
 
-	u.WithQuery(queryType{
+	u.Query(queryType{
 		Query:   "foo",
 		OrderBy: "bar",
 		Limit:   123,
 	})
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?limit=123&order_by=bar&q=foo#fragment", u)
 
-	u.WithQuery(queryType{
+	u.Query(queryType{
 		OrderBy: "baz",
 	})
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?order_by=baz#fragment", u)
 
-	u.WithQuery(queryType{})
+	u.Query(queryType{})
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/#fragment", u)
 }
 

--- a/views/urls_test.go
+++ b/views/urls_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestWithPath(t *testing.T) {
-	u := NewURLBuilder("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment")
+	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment"))
 
 	u.WithPath("foo", "123", "bar/", "456", "/baz", "789")
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/foo/123/bar/456/baz/789?query=string#fragment", u)
 }
 
 func TestAddQuery(t *testing.T) {
-	u := NewURLBuilder("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment")
+	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment"))
 
 	u.AddQuery("foo", "123")
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?foo=123&query=string#fragment", u) // query params are added in alphabetical order
@@ -38,7 +38,7 @@ type queryType struct {
 }
 
 func TestWithQuery(t *testing.T) {
-	u := NewURLBuilder("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment")
+	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment"))
 
 	u.WithQuery(queryType{
 		Query:   "foo",
@@ -57,7 +57,7 @@ func TestWithQuery(t *testing.T) {
 }
 
 func TestClearQuery(t *testing.T) {
-	u := NewURLBuilder("https://user:Pa$$w0rd@example.com:8081/test/path/?foo=123&query=string#fragment")
+	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?foo=123&query=string#fragment"))
 
 	u.ClearQuery()
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/#fragment", u)
@@ -76,4 +76,13 @@ func assertUrl(t *testing.T, expected string, actual *URLBuilder) {
 
 	// assert as SafeURL (implicit string)
 	require.Equal(t, templ.SafeURL(expected), actual.SafeURL())
+}
+
+func parseURL(u string) *url.URL {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+
+	return parsed
 }

--- a/views/urls_test.go
+++ b/views/urls_test.go
@@ -37,7 +37,7 @@ type queryType struct {
 	Limit   int    `query:"limit,omitempty"`
 }
 
-func TestQuery(t *testing.T) {
+func TestQueryWithStruct(t *testing.T) {
 	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment"))
 
 	u.Query(queryType{
@@ -54,6 +54,16 @@ func TestQuery(t *testing.T) {
 
 	u.Query(queryType{})
 	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/#fragment", u)
+}
+
+func TestQueryWithString(t *testing.T) {
+	u := URL(parseURL("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment"))
+
+	u.Query("foo=123&bar=456")
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?foo=123&bar=456#fragment", u)
+
+	u.Query("foo=321&bar=654&baz=987")
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?foo=321&bar=654&baz=987#fragment", u)
 }
 
 func TestClearQuery(t *testing.T) {

--- a/views/urls_test.go
+++ b/views/urls_test.go
@@ -1,0 +1,79 @@
+package views
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithPath(t *testing.T) {
+	u := NewURLBuilder("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment")
+
+	u.WithPath("foo", "123", "bar/", "456", "/baz", "789")
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/foo/123/bar/456/baz/789?query=string#fragment", u)
+}
+
+func TestAddQuery(t *testing.T) {
+	u := NewURLBuilder("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment")
+
+	u.AddQuery("foo", "123")
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?foo=123&query=string#fragment", u) // query params are added in alphabetical order
+
+	u.AddQuery("bar", "456")
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?bar=456&foo=123&query=string#fragment", u)
+
+	u.AddQuery("baz", "789")
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?bar=456&baz=789&foo=123&query=string#fragment", u)
+
+	u.AddQuery("bar", "123")
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?bar=456&bar=123&baz=789&foo=123&query=string#fragment", u)
+}
+
+type queryType struct {
+	Query   string `query:"q,omitempty"`
+	OrderBy string `query:"order_by,omitempty"`
+	Limit   int    `query:"limit,omitempty"`
+}
+
+func TestWithQuery(t *testing.T) {
+	u := NewURLBuilder("https://user:Pa$$w0rd@example.com:8081/test/path/?query=string#fragment")
+
+	u.WithQuery(queryType{
+		Query:   "foo",
+		OrderBy: "bar",
+		Limit:   123,
+	})
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?limit=123&order_by=bar&q=foo#fragment", u)
+
+	u.WithQuery(queryType{
+		OrderBy: "baz",
+	})
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/?order_by=baz#fragment", u)
+
+	u.WithQuery(queryType{})
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/#fragment", u)
+}
+
+func TestClearQuery(t *testing.T) {
+	u := NewURLBuilder("https://user:Pa$$w0rd@example.com:8081/test/path/?foo=123&query=string#fragment")
+
+	u.ClearQuery()
+	assertUrl(t, "https://user:Pa$$w0rd@example.com:8081/test/path/#fragment", u)
+}
+
+func assertUrl(t *testing.T, expected string, actual *URLBuilder) {
+	// assert as string
+	require.Equal(t, expected, actual.String())
+
+	// assert as URL struct
+	url, err := url.Parse(expected)
+	if err != nil {
+		t.Errorf("invalid expected url: %s", err)
+	}
+	require.Equal(t, url, actual.URL())
+
+	// assert as SafeURL (implicit string)
+	require.Equal(t, templ.SafeURL(expected), actual.SafeURL())
+}


### PR DESCRIPTION
Roughly related to #1402 

Currently only implemented these methods:

- Adapting methods:
  - `.WithPath(path ...string)`
  - `.AddQuery(key string, value string)`
  - `.WithQuery(query any)` ([see review](https://github.com/ugent-library/biblio-backoffice/pull/1476#discussion_r1585938615))
  - `.ClearQuery()`
- Build methods: 
  - `.URL() *url.URL`
  - `.String() string`
  - `.SafeURL() templ.SafeURL`


We can add more when we have use cases for them.