### PR TITLE
do not translate values of facet reviewer_tags

### DIFF
--- a/views/dataset/search.templ
+++ b/views/dataset/search.templ
@@ -43,7 +43,7 @@ templ CurationFacets(c *ctx.Ctx, searchArgs *models.SearchArgs, facets map[strin
 		@views.Facet(c, "identifier_type", "Persistent identifier type", "identifier", "identifier_type", facets["identifier_type"], searchArgs)
 	}
 	@views.FacetLine() {
-		@views.Facet(c, "reviewer_tags", "Librarian tags", "reviewer_tags", "reviewer_tags", facets["reviewer_tags"], searchArgs)
+		@views.Facet(c, "reviewer_tags", "Librarian tags", "", "", facets["reviewer_tags"], searchArgs)
 		@views.Facet(c, "has_message", "Message", "has_message", "has_message", facets["has_message"], searchArgs)
 		@views.FacetSince(c, "created_since", "Created since", "Show records created since", searchArgs)
 		@views.FacetSince(c, "updated_since", "Updated since", "Show records updated since", searchArgs)

--- a/views/dataset/search_templ.go
+++ b/views/dataset/search_templ.go
@@ -175,7 +175,7 @@ func CurationFacets(c *ctx.Ctx, searchArgs *models.SearchArgs, facets map[string
 				templ_7745c5c3_Buffer = templ.GetBuffer()
 				defer templ.ReleaseBuffer(templ_7745c5c3_Buffer)
 			}
-			templ_7745c5c3_Err = views.Facet(c, "reviewer_tags", "Librarian tags", "reviewer_tags", "reviewer_tags", facets["reviewer_tags"], searchArgs).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = views.Facet(c, "reviewer_tags", "Librarian tags", "", "", facets["reviewer_tags"], searchArgs).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
What it fixes: in a previous commit I added localization prefixes `reviewer_tags` when configuring the facet `reviewer_tags`. So if you have tags like `mytag` they now appear as `reviewer_tags.mytag`. This bug only appears in the route `/dataset`.