### PR TITLE
dataset view (show/edit) did not show identifier(type) when manually created

### DIFF
--- a/cypress/e2e/issues/issue-1237.cy.ts
+++ b/cypress/e2e/issues/issue-1237.cy.ts
@@ -675,7 +675,7 @@ describe("Issue #1237: Accessibility and mark-up: make sure labels are clickable
         cy.visitDataset();
 
         cy.updateFields("Dataset details", () => {
-          cy.intercept("PUT", "/dataset/*/details/edit/refresh-form*").as(
+          cy.intercept("PUT", "/dataset/*/details/edit/refresh*").as(
             "refreshForm",
           );
           cy.setFieldByLabel("License", "The license is not listed here");

--- a/cypress/e2e/issues/issue-1241.cy.ts
+++ b/cypress/e2e/issues/issue-1241.cy.ts
@@ -92,7 +92,7 @@ describe("Issue #1241: As a researcher or librarian, I should not be able to sel
 
       cy.ensureModal("Edit dataset details")
         .within(() => {
-          cy.intercept("PUT", "/dataset/*/details/edit/refresh-form*").as(
+          cy.intercept("PUT", "/dataset/*/details/edit/refresh*").as(
             "refreshForm",
           );
 

--- a/cypress/e2e/issues/issue-1247.cy.ts
+++ b/cypress/e2e/issues/issue-1247.cy.ts
@@ -135,7 +135,7 @@ describe("Issue #1247: User menu popup hidden behind publication details", () =>
           .click();
         cy.setFieldByLabel("Publisher", "UGent");
 
-        cy.intercept("PUT", "/dataset/*/details/edit/refresh-form").as(
+        cy.intercept("PUT", "/dataset/*/details/edit/refresh").as(
           "refreshForm",
         );
 

--- a/cypress/e2e/issues/issue-1402.cy.ts
+++ b/cypress/e2e/issues/issue-1402.cy.ts
@@ -575,9 +575,7 @@ describe("Issue #1402: Gohtml conversion to Templ", () => {
         cy.get("input[name=file]").selectFile("cypress/fixtures/empty-pdf.pdf");
         cy.ensureModal("Document details for file empty-pdf.pdf")
           .within(() => {
-            cy.intercept("/publication/*/files/*/refresh-form*").as(
-              "refreshForm",
-            );
+            cy.intercept("/publication/*/files/*/refresh*").as("refreshForm");
 
             cy.setFieldByLabel("Document type", "Peer review report");
             cy.wait("@refreshForm");

--- a/cypress/e2e/routing.cy.ts
+++ b/cypress/e2e/routing.cy.ts
@@ -155,7 +155,7 @@ describe("Authorization", () => {
     testForbiddenDatasetRoute("/message", "PUT");
 
     testForbiddenDatasetRoute("/details/edit", "GET", "PUT");
-    testForbiddenDatasetRoute("/details/edit/refresh-form", "PUT");
+    testForbiddenDatasetRoute("/details/edit/refresh", "PUT");
 
     testForbiddenDatasetRoute("/projects/add");
     testForbiddenDatasetRoute("/projects/suggestions");

--- a/cypress/support/commands/set-up-dataset.ts
+++ b/cypress/support/commands/set-up-dataset.ts
@@ -60,7 +60,7 @@ export default function setUpDataset({
           new Date().getFullYear().toString(),
         );
 
-        cy.intercept("PUT", "/dataset/*/details/edit/refresh-form").as(
+        cy.intercept("PUT", "/dataset/*/details/edit/refresh").as(
           "refreshForm",
         );
 

--- a/locales/en/default.po
+++ b/locales/en/default.po
@@ -2016,6 +2016,12 @@ msgstr "Identifier is required"
 msgid "validation.dataset.identifier.invalid"
 msgstr "Identifier is invalid"
 
+msgid "validation.dataset.identifier_type.required"
+msgstr "Identifier type is required"
+
+msgid "validation.dataset.identifier_type.invalid"
+msgstr "Identifier type is invalid"
+
 msgid "validation.dataset.access_level.required"
 msgstr "Access level is required"
 

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -83,6 +83,22 @@ func (d *Dataset) FirstIdentifier() (string, []string) { // TODO eliminate need 
 	return "", nil
 }
 
+// TODO: remove when we really support multiple identifiers
+func (d *Dataset) IdentifierType() string {
+	for key := range d.Identifiers {
+		return key
+	}
+	return ""
+}
+
+// TODO: remove when we really support multiple identifiers
+func (d *Dataset) IdentifierValue() string {
+	for _, vals := range d.Identifiers {
+		return vals[0]
+	}
+	return ""
+}
+
 func (d *Dataset) HasRelatedPublication(id string) bool {
 	for _, r := range d.RelatedPublication {
 		if r.ID == id {

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -293,7 +293,7 @@ func (d *Dataset) Validate() error {
 		errs.Add(okay.NewError("/access_level", "dataset.access_level.invalid"))
 	}
 
-	if len(d.Identifiers) == 0 {
+	if d.Status == "public" && len(d.Identifiers) == 0 {
 		errs.Add(okay.NewError("/identifier_type", "dataset.identifier_type.required"))
 		errs.Add(okay.NewError("/identifier", "dataset.identifier.required"))
 	}

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -293,16 +293,18 @@ func (d *Dataset) Validate() error {
 		errs.Add(okay.NewError("/access_level", "dataset.access_level.invalid"))
 	}
 
-	if d.Status == "public" && len(d.Identifiers) == 0 {
+	if len(d.Identifiers) == 0 {
+		errs.Add(okay.NewError("/identifier_type", "dataset.identifier_type.required"))
 		errs.Add(okay.NewError("/identifier", "dataset.identifier.required"))
 	}
 	for key, vals := range d.Identifiers {
 		if key == "" {
-			errs.Add(okay.NewError("/identifier", "dataset.identifier.required"))
-			break
+			errs.Add(okay.NewError("/identifier_type", "dataset.identifier_type.required"))
 		} else if !slices.Contains(vocabularies.Map["dataset_identifier_types"], key) {
-			errs.Add(okay.NewError("/identifier", "dataset.identifier.invalid"))
-			break
+			errs.Add(okay.NewError("/identifier_type", "dataset.identifier_type.invalid"))
+		}
+		if len(vals) == 0 {
+			errs.Add(okay.NewError("/identifier", "dataset.identifier.required"))
 		}
 		for _, val := range vals {
 			if val == "" {

--- a/views/dataset/details.templ
+++ b/views/dataset/details.templ
@@ -5,8 +5,8 @@ import (
 	"github.com/ugent-library/biblio-backoffice/models"
 	"github.com/ugent-library/biblio-backoffice/views/display"
 	"github.com/ugent-library/biblio-backoffice/identifiers"
-	"github.com/ugent-library/biblio-backoffice/vocabularies"
 	"github.com/ugent-library/biblio-backoffice/localize"
+	"github.com/samber/lo"
 )
 
 templ Details(c *ctx.Ctx, dataset *models.Dataset) {
@@ -44,41 +44,6 @@ templ detailsSection() {
 	</li>
 }
 
-func datasetIdentifierTypeAndValueDisplays(c *ctx.Ctx, dataset *models.Dataset) []templ.Component {
-	var identifier, identifierType string
-	for _, key := range vocabularies.Map["dataset_identifier_types"] {
-		if val := dataset.Identifiers.Get(key); val != "" {
-			identifierType = key
-			identifier = val
-		}
-	}
-
-	identifierTypeArgs := display.FieldArgs{
-		Label:    c.Loc.Get("builder.identifier_type"),
-		Required: true,
-	}
-	if identifierType != "" {
-		identifierTypeArgs.Value = c.Loc.Get("identifier." + identifierType)
-	}
-
-	identifierArgs := display.FieldArgs{
-		Label:    c.Loc.Get("builder.identifier"),
-		Required: true,
-	}
-	if identifierType == "" {
-		identifierArgs.Value = identifier
-	} else if identifier != "" {
-		identifierArgs.Content = display.Link(identifier, func(_ string) string {
-			return identifiers.Resolve(identifierType, identifier)
-		})
-	}
-
-	return []templ.Component{
-		display.Field(identifierTypeArgs),
-		display.Field(identifierArgs),
-	}
-}
-
 templ DetailsBody(c *ctx.Ctx, dataset *models.Dataset) {
 	<div class="card-body p-0">
 		<ul class="list-group list-group-flush" data-panel-state="read">
@@ -88,9 +53,23 @@ templ DetailsBody(c *ctx.Ctx, dataset *models.Dataset) {
 					Value:    dataset.Title,
 					Required: true,
 				})
-				for _, comp := range datasetIdentifierTypeAndValueDisplays(c, dataset) {
-					@comp
-				}
+				@display.Field(display.FieldArgs{
+					Label:    c.Loc.Get("builder.identifier_type"),
+					Required: true,
+					Value:    lo.Ternary(dataset.IdentifierType() != "", c.Loc.Get("identifier."+dataset.IdentifierType()), ""),
+				})
+				@display.Field(display.FieldArgs{
+					Label:    c.Loc.Get("builder.identifier"),
+					Required: true,
+					Value:    dataset.IdentifierValue(),
+					Content: lo.Ternary(
+						dataset.IdentifierValue() != "" && dataset.IdentifierType() != "",
+						display.Link(dataset.IdentifierValue(), func(val string) string {
+							return identifiers.Resolve(dataset.IdentifierType(), val)
+						}),
+						nil,
+					),
+				})
 			}
 			@detailsSection() {
 				@display.Field(display.FieldArgs{

--- a/views/dataset/details.templ
+++ b/views/dataset/details.templ
@@ -65,7 +65,7 @@ templ DetailsBody(c *ctx.Ctx, dataset *models.Dataset) {
 					Value:    dataset.Title,
 					Required: true,
 				})
-				if identifierType, identifier := getDatasetIdentifierAndType(dataset); identifierType != "" {
+				if identifierType, identifier := getDatasetIdentifierAndType(dataset); true {
 					@display.Field(display.FieldArgs{
 						Label:    c.Loc.Get("builder.identifier_type"),
 						Value:    c.Loc.Get("identifier." + identifierType),

--- a/views/dataset/details.templ
+++ b/views/dataset/details.templ
@@ -44,16 +44,39 @@ templ detailsSection() {
 	</li>
 }
 
-func getDatasetIdentifierAndType(dataset *models.Dataset) (string, string) {
-	var identifierType, identifier string
+func datasetIdentifierTypeAndValueDisplays(c *ctx.Ctx, dataset *models.Dataset) []templ.Component {
+	var identifier, identifierType string
 	for _, key := range vocabularies.Map["dataset_identifier_types"] {
 		if val := dataset.Identifiers.Get(key); val != "" {
 			identifierType = key
 			identifier = val
-			break
 		}
 	}
-	return identifierType, identifier
+
+	identifierTypeArgs := display.FieldArgs{
+		Label:    c.Loc.Get("builder.identifier_type"),
+		Required: true,
+	}
+	if identifierType != "" {
+		identifierTypeArgs.Value = c.Loc.Get("identifier." + identifierType)
+	}
+
+	identifierArgs := display.FieldArgs{
+		Label:    c.Loc.Get("builder.identifier"),
+		Required: true,
+	}
+	if identifierType == "" {
+		identifierArgs.Value = identifier
+	} else if identifier != "" {
+		identifierArgs.Content = display.Link(identifier, func(_ string) string {
+			return identifiers.Resolve(identifierType, identifier)
+		})
+	}
+
+	return []templ.Component{
+		display.Field(identifierTypeArgs),
+		display.Field(identifierArgs),
+	}
 }
 
 templ DetailsBody(c *ctx.Ctx, dataset *models.Dataset) {
@@ -65,20 +88,8 @@ templ DetailsBody(c *ctx.Ctx, dataset *models.Dataset) {
 					Value:    dataset.Title,
 					Required: true,
 				})
-				if identifierType, identifier := getDatasetIdentifierAndType(dataset); true {
-					@display.Field(display.FieldArgs{
-						Label:    c.Loc.Get("builder.identifier_type"),
-						Value:    c.Loc.Get("identifier." + identifierType),
-						Required: true,
-					})
-					@display.Field(display.FieldArgs{
-						Label: c.Loc.Get("builder.identifier"),
-						Value: identifier,
-						Content: display.Link(identifier, func(_ string) string {
-							return identifiers.Resolve(identifierType, identifier)
-						}),
-						Required: true,
-					})
+				for _, comp := range datasetIdentifierTypeAndValueDisplays(c, dataset) {
+					@comp
 				}
 			}
 			@detailsSection() {

--- a/views/dataset/details_templ.go
+++ b/views/dataset/details_templ.go
@@ -148,7 +148,7 @@ func DetailsBody(c *ctx.Ctx, dataset *models.Dataset) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if identifierType, identifier := getDatasetIdentifierAndType(dataset); identifierType != "" {
+			if identifierType, identifier := getDatasetIdentifierAndType(dataset); true {
 				templ_7745c5c3_Err = display.Field(display.FieldArgs{
 					Label:    c.Loc.Get("builder.identifier_type"),
 					Value:    c.Loc.Get("identifier." + identifierType),

--- a/views/dataset/details_templ.go
+++ b/views/dataset/details_templ.go
@@ -11,12 +11,12 @@ import "io"
 import "bytes"
 
 import (
+	"github.com/samber/lo"
 	"github.com/ugent-library/biblio-backoffice/ctx"
 	"github.com/ugent-library/biblio-backoffice/identifiers"
 	"github.com/ugent-library/biblio-backoffice/localize"
 	"github.com/ugent-library/biblio-backoffice/models"
 	"github.com/ugent-library/biblio-backoffice/views/display"
-	"github.com/ugent-library/biblio-backoffice/vocabularies"
 )
 
 func Details(c *ctx.Ctx, dataset *models.Dataset) templ.Component {
@@ -101,41 +101,6 @@ func detailsSection() templ.Component {
 	})
 }
 
-func datasetIdentifierTypeAndValueDisplays(c *ctx.Ctx, dataset *models.Dataset) []templ.Component {
-	var identifier, identifierType string
-	for _, key := range vocabularies.Map["dataset_identifier_types"] {
-		if val := dataset.Identifiers.Get(key); val != "" {
-			identifierType = key
-			identifier = val
-		}
-	}
-
-	identifierTypeArgs := display.FieldArgs{
-		Label:    c.Loc.Get("builder.identifier_type"),
-		Required: true,
-	}
-	if identifierType != "" {
-		identifierTypeArgs.Value = c.Loc.Get("identifier." + identifierType)
-	}
-
-	identifierArgs := display.FieldArgs{
-		Label:    c.Loc.Get("builder.identifier"),
-		Required: true,
-	}
-	if identifierType == "" {
-		identifierArgs.Value = identifier
-	} else if identifier != "" {
-		identifierArgs.Content = display.Link(identifier, func(_ string) string {
-			return identifiers.Resolve(identifierType, identifier)
-		})
-	}
-
-	return []templ.Component{
-		display.Field(identifierTypeArgs),
-		display.Field(identifierArgs),
-	}
-}
-
 func DetailsBody(c *ctx.Ctx, dataset *models.Dataset) templ.Component {
 	return templ.ComponentFunc(func(ctx context.Context, templ_7745c5c3_W io.Writer) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templ_7745c5c3_W.(*bytes.Buffer)
@@ -171,11 +136,32 @@ func DetailsBody(c *ctx.Ctx, dataset *models.Dataset) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, comp := range datasetIdentifierTypeAndValueDisplays(c, dataset) {
-				templ_7745c5c3_Err = comp.Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
+			templ_7745c5c3_Err = display.Field(display.FieldArgs{
+				Label:    c.Loc.Get("builder.identifier_type"),
+				Required: true,
+				Value:    lo.Ternary(dataset.IdentifierType() != "", c.Loc.Get("identifier."+dataset.IdentifierType()), ""),
+			}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = display.Field(display.FieldArgs{
+				Label:    c.Loc.Get("builder.identifier"),
+				Required: true,
+				Value:    dataset.IdentifierValue(),
+				Content: lo.Ternary(
+					dataset.IdentifierValue() != "" && dataset.IdentifierType() != "",
+					display.Link(dataset.IdentifierValue(), func(val string) string {
+						return identifiers.Resolve(dataset.IdentifierType(), val)
+					}),
+					nil,
+				),
+			}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
 			}
 			if !templ_7745c5c3_IsBuffer {
 				_, templ_7745c5c3_Err = io.Copy(templ_7745c5c3_W, templ_7745c5c3_Buffer)

--- a/views/dataset/edit_details.templ
+++ b/views/dataset/edit_details.templ
@@ -21,46 +21,6 @@ func datasetIdentifierOptions(loc *gotext.Locale) []form.Option {
 	return identifierTypeOptions
 }
 
-func datasetIdentifierTypeAndValueFields(c *ctx.Ctx, dataset *models.Dataset, errors *okay.Errors) []templ.Component {
-	var identifier, identifierType string
-	for key, vals := range dataset.Identifiers {
-		identifierType = key
-		for _, val := range vals {
-			identifier = val
-			break
-		}
-		break
-	}
-
-	return []templ.Component{
-		form.Select(form.SelectArgs{
-			FieldArgs: form.FieldArgs{
-				Name:     "identifier_type",
-				Label:    c.Loc.Get("builder.identifier_type"),
-				Cols:     3,
-				Help:     c.Loc.Get("builder.identifier_type.help"),
-				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier_type"),
-				Required: true,
-			},
-			Value:       identifierType,
-			EmptyOption: true,
-			Options:     datasetIdentifierOptions(c.Loc),
-		}),
-		form.Text(form.TextArgs{
-			FieldArgs: form.FieldArgs{
-				Name:     "identifier",
-				Label:    c.Loc.Get("builder.identifier"),
-				Required: true,
-				Cols:     3,
-				Help:     c.Loc.Get("builder.identifier.help"),
-				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
-				Tooltip:  c.Loc.Get("tooltip.dataset.identifier"),
-			},
-			Value: identifier,
-		}),
-	}
-}
-
 func nextDay() time.Time {
 	now := time.Now()
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).Add(24 * time.Hour)
@@ -92,9 +52,31 @@ templ EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, erro
 							},
 							Value: dataset.Title,
 						})
-						for _, comp := range datasetIdentifierTypeAndValueFields(c, dataset, errors) {
-							@comp
-						}
+						@form.Select(form.SelectArgs{
+							FieldArgs: form.FieldArgs{
+								Name:     "identifier_type",
+								Label:    c.Loc.Get("builder.identifier_type"),
+								Cols:     3,
+								Help:     c.Loc.Get("builder.identifier_type.help"),
+								Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier_type"),
+								Required: true,
+							},
+							Value:       dataset.IdentifierType(),
+							EmptyOption: true,
+							Options:     datasetIdentifierOptions(c.Loc),
+						})
+						@form.Text(form.TextArgs{
+							FieldArgs: form.FieldArgs{
+								Name:     "identifier",
+								Label:    c.Loc.Get("builder.identifier"),
+								Required: true,
+								Cols:     3,
+								Help:     c.Loc.Get("builder.identifier.help"),
+								Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
+								Tooltip:  c.Loc.Get("tooltip.dataset.identifier"),
+							},
+							Value: dataset.IdentifierValue(),
+						})
 					</li>
 					<li class="list-group-item">
 						@form.SelectRepeat(form.SelectRepeatArgs{

--- a/views/dataset/edit_details.templ
+++ b/views/dataset/edit_details.templ
@@ -12,18 +12,6 @@ import (
 	"time"
 )
 
-func datasetIdentifierAndType(dataset *models.Dataset) (string, string) {
-	var identifierType, identifier string
-	for _, key := range vocabularies.Map["dataset_identifier_types"] {
-		if val := dataset.Identifiers.Get(key); val != "" {
-			identifierType = key
-			identifier = val
-			break
-		}
-	}
-	return identifier, identifierType
-}
-
 func datasetIdentifierOptions(loc *gotext.Locale) []form.Option {
 	identifierTypeOptions := make([]form.Option, len(vocabularies.Map["dataset_identifier_types"]))
 	for i, v := range vocabularies.Map["dataset_identifier_types"] {
@@ -31,6 +19,46 @@ func datasetIdentifierOptions(loc *gotext.Locale) []form.Option {
 		identifierTypeOptions[i].Value = v
 	}
 	return identifierTypeOptions
+}
+
+func datasetIdentifierTypeAndValueFields(c *ctx.Ctx, dataset *models.Dataset, errors *okay.Errors) []templ.Component {
+	var identifier, identifierType string
+	for key, vals := range dataset.Identifiers {
+		identifierType = key
+		for _, val := range vals {
+			identifier = val
+			break
+		}
+		break
+	}
+
+	return []templ.Component{
+		form.Select(form.SelectArgs{
+			FieldArgs: form.FieldArgs{
+				Name:     "identifier_type",
+				Label:    c.Loc.Get("builder.identifier_type"),
+				Cols:     3,
+				Help:     c.Loc.Get("builder.identifier_type.help"),
+				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier_type"),
+				Required: true,
+			},
+			Value:       identifierType,
+			EmptyOption: true,
+			Options:     datasetIdentifierOptions(c.Loc),
+		}),
+		form.Text(form.TextArgs{
+			FieldArgs: form.FieldArgs{
+				Name:     "identifier",
+				Label:    c.Loc.Get("builder.identifier"),
+				Required: true,
+				Cols:     3,
+				Help:     c.Loc.Get("builder.identifier.help"),
+				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
+				Tooltip:  c.Loc.Get("tooltip.dataset.identifier"),
+			},
+			Value: identifier,
+		}),
+	}
 }
 
 func nextDay() time.Time {
@@ -64,32 +92,8 @@ templ EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, erro
 							},
 							Value: dataset.Title,
 						})
-						if identifier, identifierType := datasetIdentifierAndType(dataset); true {
-							@form.Select(form.SelectArgs{
-								FieldArgs: form.FieldArgs{
-									Name:     "identifier_type",
-									Label:    c.Loc.Get("builder.identifier_type"),
-									Cols:     3,
-									Help:     c.Loc.Get("builder.identifier_type.help"),
-									Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
-									Required: true,
-								},
-								Value:       identifierType,
-								EmptyOption: true,
-								Options:     datasetIdentifierOptions(c.Loc),
-							})
-							@form.Text(form.TextArgs{
-								FieldArgs: form.FieldArgs{
-									Name:     "identifier",
-									Label:    c.Loc.Get("builder.identifier"),
-									Required: true,
-									Cols:     3,
-									Help:     c.Loc.Get("builder.identifier.help"),
-									Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
-									Tooltip:  c.Loc.Get("tooltip.dataset.identifier"),
-								},
-								Value: identifier,
-							})
+						for _, comp := range datasetIdentifierTypeAndValueFields(c, dataset, errors) {
+							@comp
 						}
 					</li>
 					<li class="list-group-item">

--- a/views/dataset/edit_details.templ
+++ b/views/dataset/edit_details.templ
@@ -64,7 +64,7 @@ templ EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, erro
 							},
 							Value: dataset.Title,
 						})
-						if identifier, identifierType := datasetIdentifierAndType(dataset); identifierType != "" {
+						if identifier, identifierType := datasetIdentifierAndType(dataset); true {
 							@form.Select(form.SelectArgs{
 								FieldArgs: form.FieldArgs{
 									Name:     "identifier_type",

--- a/views/dataset/edit_details_templ.go
+++ b/views/dataset/edit_details_templ.go
@@ -22,18 +22,6 @@ import (
 	"time"
 )
 
-func datasetIdentifierAndType(dataset *models.Dataset) (string, string) {
-	var identifierType, identifier string
-	for _, key := range vocabularies.Map["dataset_identifier_types"] {
-		if val := dataset.Identifiers.Get(key); val != "" {
-			identifierType = key
-			identifier = val
-			break
-		}
-	}
-	return identifier, identifierType
-}
-
 func datasetIdentifierOptions(loc *gotext.Locale) []form.Option {
 	identifierTypeOptions := make([]form.Option, len(vocabularies.Map["dataset_identifier_types"]))
 	for i, v := range vocabularies.Map["dataset_identifier_types"] {
@@ -41,6 +29,46 @@ func datasetIdentifierOptions(loc *gotext.Locale) []form.Option {
 		identifierTypeOptions[i].Value = v
 	}
 	return identifierTypeOptions
+}
+
+func datasetIdentifierTypeAndValueFields(c *ctx.Ctx, dataset *models.Dataset, errors *okay.Errors) []templ.Component {
+	var identifier, identifierType string
+	for key, vals := range dataset.Identifiers {
+		identifierType = key
+		for _, val := range vals {
+			identifier = val
+			break
+		}
+		break
+	}
+
+	return []templ.Component{
+		form.Select(form.SelectArgs{
+			FieldArgs: form.FieldArgs{
+				Name:     "identifier_type",
+				Label:    c.Loc.Get("builder.identifier_type"),
+				Cols:     3,
+				Help:     c.Loc.Get("builder.identifier_type.help"),
+				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier_type"),
+				Required: true,
+			},
+			Value:       identifierType,
+			EmptyOption: true,
+			Options:     datasetIdentifierOptions(c.Loc),
+		}),
+		form.Text(form.TextArgs{
+			FieldArgs: form.FieldArgs{
+				Name:     "identifier",
+				Label:    c.Loc.Get("builder.identifier"),
+				Required: true,
+				Cols:     3,
+				Help:     c.Loc.Get("builder.identifier.help"),
+				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
+				Tooltip:  c.Loc.Get("tooltip.dataset.identifier"),
+			},
+			Value: identifier,
+		}),
+	}
 }
 
 func nextDay() time.Time {
@@ -92,39 +120,8 @@ func EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, error
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if identifier, identifierType := datasetIdentifierAndType(dataset); true {
-			templ_7745c5c3_Err = form.Select(form.SelectArgs{
-				FieldArgs: form.FieldArgs{
-					Name:     "identifier_type",
-					Label:    c.Loc.Get("builder.identifier_type"),
-					Cols:     3,
-					Help:     c.Loc.Get("builder.identifier_type.help"),
-					Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
-					Required: true,
-				},
-				Value:       identifierType,
-				EmptyOption: true,
-				Options:     datasetIdentifierOptions(c.Loc),
-			}).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = form.Text(form.TextArgs{
-				FieldArgs: form.FieldArgs{
-					Name:     "identifier",
-					Label:    c.Loc.Get("builder.identifier"),
-					Required: true,
-					Cols:     3,
-					Help:     c.Loc.Get("builder.identifier.help"),
-					Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
-					Tooltip:  c.Loc.Get("tooltip.dataset.identifier"),
-				},
-				Value: identifier,
-			}).Render(ctx, templ_7745c5c3_Buffer)
+		for _, comp := range datasetIdentifierTypeAndValueFields(c, dataset, errors) {
+			templ_7745c5c3_Err = comp.Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -267,7 +264,7 @@ func EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, error
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(o.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/edit_details.templ`, Line: 171, Col: 85}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/edit_details.templ`, Line: 175, Col: 85}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -375,7 +372,7 @@ func EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, error
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(o.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/edit_details.templ`, Line: 208, Col: 89}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/edit_details.templ`, Line: 212, Col: 89}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {

--- a/views/dataset/edit_details_templ.go
+++ b/views/dataset/edit_details_templ.go
@@ -31,46 +31,6 @@ func datasetIdentifierOptions(loc *gotext.Locale) []form.Option {
 	return identifierTypeOptions
 }
 
-func datasetIdentifierTypeAndValueFields(c *ctx.Ctx, dataset *models.Dataset, errors *okay.Errors) []templ.Component {
-	var identifier, identifierType string
-	for key, vals := range dataset.Identifiers {
-		identifierType = key
-		for _, val := range vals {
-			identifier = val
-			break
-		}
-		break
-	}
-
-	return []templ.Component{
-		form.Select(form.SelectArgs{
-			FieldArgs: form.FieldArgs{
-				Name:     "identifier_type",
-				Label:    c.Loc.Get("builder.identifier_type"),
-				Cols:     3,
-				Help:     c.Loc.Get("builder.identifier_type.help"),
-				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier_type"),
-				Required: true,
-			},
-			Value:       identifierType,
-			EmptyOption: true,
-			Options:     datasetIdentifierOptions(c.Loc),
-		}),
-		form.Text(form.TextArgs{
-			FieldArgs: form.FieldArgs{
-				Name:     "identifier",
-				Label:    c.Loc.Get("builder.identifier"),
-				Required: true,
-				Cols:     3,
-				Help:     c.Loc.Get("builder.identifier.help"),
-				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
-				Tooltip:  c.Loc.Get("tooltip.dataset.identifier"),
-			},
-			Value: identifier,
-		}),
-	}
-}
-
 func nextDay() time.Time {
 	now := time.Now()
 	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).Add(24 * time.Hour)
@@ -120,11 +80,36 @@ func EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, error
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, comp := range datasetIdentifierTypeAndValueFields(c, dataset, errors) {
-			templ_7745c5c3_Err = comp.Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
+		templ_7745c5c3_Err = form.Select(form.SelectArgs{
+			FieldArgs: form.FieldArgs{
+				Name:     "identifier_type",
+				Label:    c.Loc.Get("builder.identifier_type"),
+				Cols:     3,
+				Help:     c.Loc.Get("builder.identifier_type.help"),
+				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier_type"),
+				Required: true,
+			},
+			Value:       dataset.IdentifierType(),
+			EmptyOption: true,
+			Options:     datasetIdentifierOptions(c.Loc),
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = form.Text(form.TextArgs{
+			FieldArgs: form.FieldArgs{
+				Name:     "identifier",
+				Label:    c.Loc.Get("builder.identifier"),
+				Required: true,
+				Cols:     3,
+				Help:     c.Loc.Get("builder.identifier.help"),
+				Error:    localize.ValidationErrorAt(c.Loc, errors, "/identifier"),
+				Tooltip:  c.Loc.Get("tooltip.dataset.identifier"),
+			},
+			Value: dataset.IdentifierValue(),
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</li><li class=\"list-group-item\">")
 		if templ_7745c5c3_Err != nil {
@@ -264,7 +249,7 @@ func EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, error
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(o.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/edit_details.templ`, Line: 175, Col: 85}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/edit_details.templ`, Line: 157, Col: 85}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -372,7 +357,7 @@ func EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, error
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(o.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/edit_details.templ`, Line: 212, Col: 89}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/edit_details.templ`, Line: 194, Col: 89}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {

--- a/views/dataset/edit_details_templ.go
+++ b/views/dataset/edit_details_templ.go
@@ -92,7 +92,7 @@ func EditDetailsDialog(c *ctx.Ctx, dataset *models.Dataset, conflict bool, error
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if identifier, identifierType := datasetIdentifierAndType(dataset); identifierType != "" {
+		if identifier, identifierType := datasetIdentifierAndType(dataset); true {
 			templ_7745c5c3_Err = form.Select(form.SelectArgs{
 				FieldArgs: form.FieldArgs{
 					Name:     "identifier_type",


### PR DESCRIPTION
In the current dev branch, if you create a dataset **manually**, the fields identifier_type and identifier are missing
in the description (both show/edit).

Reason for this is the if-statement to get identifier and identifier_type out of the map [Identifiers](https://github.com/ugent-library/biblio-backoffice/blob/dev/models/dataset.go#L54):

* https://github.com/ugent-library/biblio-backoffice/blob/dev/views/dataset/details.templ#L68
* https://github.com/ugent-library/biblio-backoffice/blob/dev/views/dataset/edit_details.templ#L67

(P.S. there is no other way to assign variables in templ)

I replaced the `identifierType != ""` by `true` which is always true.

Not sure if we should keep storing the identifier like this

@verheyenkoen detected this