### PR TITLE
Refactor to templ: lock/unlock should redirect to dataset detail page, not dataset search page

### DIFF
--- a/views/dataset/show.templ
+++ b/views/dataset/show.templ
@@ -59,7 +59,7 @@ templ Show(c *ctx.Ctx, dataset *models.Dataset, redirectURL string) {
 								if c.User.CanCurate() && dataset.Locked {
 									<button
 										class="btn btn-outline-secondary"
-										hx-post={ views.URL(c.PathTo("dataset_unlock", "id", dataset.ID)).QuerySet("redirect-url", redirectURL).String() }
+										hx-post={ views.URL(c.PathTo("dataset_unlock", "id", dataset.ID)).QuerySet("redirect-url", c.CurrentURL.String()).String() }
 										hx-swap="none"
 									>
 										<i class="if if-lock-unlock"></i>
@@ -68,7 +68,7 @@ templ Show(c *ctx.Ctx, dataset *models.Dataset, redirectURL string) {
 								} else if c.User.CanCurate() {
 									<button
 										class="btn btn-outline-secondary"
-										hx-post={ views.URL(c.PathTo("dataset_lock", "id", dataset.ID)).QuerySet("redirect-url", redirectURL).String() }
+										hx-post={ views.URL(c.PathTo("dataset_lock", "id", dataset.ID)).QuerySet("redirect-url", c.CurrentURL.String()).String() }
 										hx-swap="none"
 									>
 										<i class="if if-lock"></i>

--- a/views/dataset/show_templ.go
+++ b/views/dataset/show_templ.go
@@ -99,7 +99,7 @@ func Show(c *ctx.Ctx, dataset *models.Dataset, redirectURL string) templ.Compone
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(views.URL(c.PathTo("dataset_unlock", "id", dataset.ID)).QuerySet("redirect-url", redirectURL).String()))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(views.URL(c.PathTo("dataset_unlock", "id", dataset.ID)).QuerySet("redirect-url", c.CurrentURL.String()).String()))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -112,7 +112,7 @@ func Show(c *ctx.Ctx, dataset *models.Dataset, redirectURL string) templ.Compone
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(views.URL(c.PathTo("dataset_lock", "id", dataset.ID)).QuerySet("redirect-url", redirectURL).String()))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(views.URL(c.PathTo("dataset_lock", "id", dataset.ID)).QuerySet("redirect-url", c.CurrentURL.String()).String()))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}


### PR DESCRIPTION
@verheyenkoen remarked that the current templ refactor of `datasetediting.Lock` and `datasetediting.Unlock` redirects the user to the dataset search page, instead of back to the dataset detail page (where that button is located).

