### PR TITLE
replace c.Log by c.HandleError with wrapped errors

### DIFF
--- a/handlers/candidaterecords/candidaterecords.go
+++ b/handlers/candidaterecords/candidaterecords.go
@@ -22,8 +22,7 @@ func CandidateRecords(w http.ResponseWriter, r *http.Request) {
 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.Request(r, searchArgs); err != nil {
-		c.Log.Warnw("could not bind search arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -58,8 +57,7 @@ func CandidateRecordPreview(w http.ResponseWriter, r *http.Request) {
 
 	b := bindCandidateRecord{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("preview candidate record: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -93,8 +91,7 @@ func ConfirmRejectCandidateRecord(w http.ResponseWriter, r *http.Request) {
 
 	b := bindCandidateRecord{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm reject candidate record: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -117,8 +114,7 @@ func RejectCandidateRecord(w http.ResponseWriter, r *http.Request) {
 
 	b := bindCandidateRecord{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("reject candidate record: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -147,8 +143,7 @@ func ImportCandidateRecord(w http.ResponseWriter, r *http.Request) {
 
 	b := bindCandidateRecord{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("import candidate record: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 

--- a/handlers/candidaterecords/file.go
+++ b/handlers/candidaterecords/file.go
@@ -3,7 +3,6 @@ package candidaterecords
 import (
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 
@@ -22,8 +21,7 @@ func DownloadFile(w http.ResponseWriter, r *http.Request) {
 
 	b := bindCandidateRecord{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("preview candidate record: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -36,14 +34,13 @@ func DownloadFile(w http.ResponseWriter, r *http.Request) {
 	f := rec.Publication.GetFile(bind.PathValue(r, "file_id"))
 
 	if f == nil {
-		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		c.HandleError(w, r, httperror.NotFound)
 		return
 	}
 
 	rc, err := c.FileStore.Get(r.Context(), f.SHA256)
 	if err != nil {
-		log.Printf("%+v", err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(err))
 		return
 	}
 	defer rc.Close()
@@ -54,6 +51,4 @@ func DownloadFile(w http.ResponseWriter, r *http.Request) {
 	)
 
 	io.Copy(w, rc)
-
-	fmt.Fprintf(w, "test")
 }

--- a/handlers/dashboard/datasets.go
+++ b/handlers/dashboard/datasets.go
@@ -44,8 +44,7 @@ func CuratorDatasets(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if err != nil {
-		c.Log.Errorw("Dashboard: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 	views.CuratorDashboardDatasets(c, &views.CuratorDashboardDatasetsArgs{

--- a/handlers/dashboard/publications.go
+++ b/handlers/dashboard/publications.go
@@ -45,20 +45,17 @@ func CuratorPublications(w http.ResponseWriter, r *http.Request) {
 
 	allUPublicationYears, err := allUPublicationYears(c.PublicationSearchIndex)
 	if err != nil {
-		c.Log.Errorw("Dashboard: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 	allAPublicationYears, err := allAPublicationYears(c.PublicationSearchIndex)
 	if err != nil {
-		c.Log.Errorw("Dashboard: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 	bindPublications := BindPublications{}
 	if err := bind.Request(r, &bindPublications); err != nil {
-		c.Log.Warnw("publication dashboard could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -90,8 +87,7 @@ func CuratorPublications(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if err != nil {
-		c.Log.Errorw("Dashboard: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -119,8 +115,7 @@ func CuratorPublications(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if err != nil {
-		c.Log.Errorw("Dashboard: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -158,8 +153,7 @@ func RefreshAPublications(w http.ResponseWriter, r *http.Request) {
 
 	bindPublications := BindPublications{}
 	if err := bind.Request(r, &bindPublications); err != nil {
-		c.Log.Warnw("publication dashboard could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -185,8 +179,7 @@ func RefreshAPublications(w http.ResponseWriter, r *http.Request) {
 		return args
 	})
 	if err != nil {
-		c.Log.Errorw("Dashboard: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -221,8 +214,7 @@ func RefreshUPublications(w http.ResponseWriter, r *http.Request) {
 
 	bindPublications := BindPublications{}
 	if err := bind.Request(r, &bindPublications); err != nil {
-		c.Log.Warnw("publication dashboard could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -249,8 +241,7 @@ func RefreshUPublications(w http.ResponseWriter, r *http.Request) {
 		return args
 	})
 	if err != nil {
-		c.Log.Errorw("Dashboard: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 

--- a/handlers/datasetcreating/import.go
+++ b/handlers/datasetcreating/import.go
@@ -34,8 +34,7 @@ func Add(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAdd{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("add dataset: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -56,8 +55,7 @@ func ConfirmImport(w http.ResponseWriter, r *http.Request) {
 
 	b := BindImport{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("confirm import dataset: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -68,8 +66,7 @@ func ConfirmImport(w http.ResponseWriter, r *http.Request) {
 		existing, err := c.DatasetSearchIndex.Search(args)
 
 		if err != nil {
-			c.Log.Errorw("confirm import dataset: could not execute search", "errors", err, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 			return
 		}
 
@@ -92,8 +89,7 @@ func AddImport(w http.ResponseWriter, r *http.Request) {
 
 	b := BindImport{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("add import dataset: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -146,8 +142,7 @@ func AddImport(w http.ResponseWriter, r *http.Request) {
 	err = c.Repo.SaveDataset(d, c.User)
 
 	if err != nil {
-		c.Log.Warnw("add import dataset: could not save dataset:", "errors", err, "dataset", b.Identifier, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save dataset: %w", err)))
 		return
 	}
 
@@ -209,8 +204,7 @@ func AddPublish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Warnf("create dataset: Could not save the dataset:", "error", err, "identifier", dataset.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/abstract.go
+++ b/handlers/datasetediting/abstract.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -41,8 +42,7 @@ func CreateAbstract(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("create dataset abstract: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -79,8 +79,7 @@ func CreateAbstract(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create dataset abstract: could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -93,8 +92,7 @@ func EditAbstract(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("edit dataset abstract: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -120,8 +118,7 @@ func UpdateAbstract(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset abstract: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -174,8 +171,7 @@ func UpdateAbstract(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Warnf("update dataset abstract: Could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -188,8 +184,7 @@ func ConfirmDeleteAbstract(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteAbstract
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete dataset: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -211,8 +206,7 @@ func DeleteAbstract(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteAbstract
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete datase abstract: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -228,8 +222,7 @@ func DeleteAbstract(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Warnf("delete dataset abstract: Could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/activity.go
+++ b/handlers/datasetediting/activity.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -39,8 +40,7 @@ func UpdateMessage(w http.ResponseWriter, r *http.Request) {
 
 	b := BindMessage{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset reviewer note: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -69,8 +69,7 @@ func UpdateMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update dataset message: could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -91,8 +90,7 @@ func UpdateReviewerTags(w http.ResponseWriter, r *http.Request) {
 
 	b := BindReviewerTags{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset reviewer tags: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -121,8 +119,7 @@ func UpdateReviewerTags(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update dataset reviewer tags: could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -143,8 +140,7 @@ func UpdateReviewerNote(w http.ResponseWriter, r *http.Request) {
 
 	b := BindReviewerNote{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset reviewer note: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -173,8 +169,7 @@ func UpdateReviewerNote(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update dataset reviewer note: could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/contributors.go
+++ b/handlers/datasetediting/contributors.go
@@ -91,8 +91,7 @@ func AddContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAddContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("add dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -101,8 +100,7 @@ func AddContributor(w http.ResponseWriter, r *http.Request) {
 	if b.FirstName != "" || b.LastName != "" {
 		people, err := c.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
-			c.Log.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 			return
 		}
 
@@ -126,8 +124,7 @@ func AddContributorSuggest(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAddContributorSuggest{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("suggest dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -136,8 +133,7 @@ func AddContributorSuggest(w http.ResponseWriter, r *http.Request) {
 	if b.FirstName != "" || b.LastName != "" {
 		people, err := c.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
-			c.Log.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 			return
 		}
 
@@ -163,8 +159,7 @@ func ConfirmCreateContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindConfirmCreateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("confirm create dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -195,8 +190,7 @@ func CreateContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindCreateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("create dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -241,8 +235,7 @@ func CreateContributor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create dataset contributor: Could not save the dataset:", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save dataset: %w", err)))
 		return
 	}
 
@@ -272,15 +265,13 @@ func EditContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindEditContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("edit dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	cn, err := dataset.GetContributor(b.Role, b.Position)
 	if err != nil {
-		c.Log.Errorw("edit dataset contributor: could not get the contributor", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get the contributor: %w", err)))
 		return
 	}
 
@@ -293,8 +284,7 @@ func EditContributor(w http.ResponseWriter, r *http.Request) {
 
 	people, err := c.PersonSearchService.SuggestPeople(firstName + " " + lastName)
 	if err != nil {
-		c.Log.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 		return
 	}
 
@@ -334,15 +324,13 @@ func EditContributorSuggest(w http.ResponseWriter, r *http.Request) {
 
 	b := BindEditContributorSuggest{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("suggest dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	cn, err := dataset.GetContributor(b.Role, b.Position)
 	if err != nil {
-		c.Log.Errorw("edit dataset contributor: could not get the contributor", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get the contributor: %w", err)))
 		return
 	}
 
@@ -351,8 +339,7 @@ func EditContributorSuggest(w http.ResponseWriter, r *http.Request) {
 	if b.FirstName != "" || b.LastName != "" {
 		people, err := c.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
-			c.Log.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 			return
 		}
 
@@ -389,8 +376,7 @@ func ConfirmUpdateContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindConfirmUpdateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("confirm update dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -421,8 +407,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindUpdateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -430,8 +415,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 	if b.ID != "" {
 		newC, err := generateContributorFromPersonId(c, b.ID)
 		if err != nil {
-			c.Log.Errorw("update dataset contributor: could not fetch person", "errors", err, "personid", b.ID, "dataset", dataset.ID, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not fetch person: %w", err)))
 			return
 		}
 		cn = newC
@@ -446,8 +430,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := dataset.SetContributor(b.Role, b.Position, cn); err != nil {
-		c.Log.Errorw("update dataset contributor: could not set the contributor", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not set the contributor: %w", err)))
 		return
 	}
 
@@ -472,8 +455,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update dataset contributor: Could not save the dataset:", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -482,8 +464,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 		nextC := dataset.Contributors(b.Role)[nextPos]
 		people, err := c.PersonSearchService.SuggestPeople(nextC.Name())
 		if err != nil {
-			c.Log.Errorw("suggest dataset contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 			return
 		}
 		hits := make([]*models.Contributor, len(people))
@@ -517,8 +498,7 @@ func ConfirmDeleteContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -536,14 +516,12 @@ func DeleteContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete dataset contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	if err := dataset.RemoveContributor(b.Role, b.Position); err != nil {
-		c.Log.Warnw("delete dataset contributor: could not remove contributor", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not remove contributor: %w", err)))
 		return
 	}
 
@@ -562,8 +540,7 @@ func DeleteContributor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete dataset contributor: Could not save the dataset:", "error", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -579,16 +556,13 @@ func OrderContributors(w http.ResponseWriter, r *http.Request) {
 
 	b := BindOrderContributors{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("order dataset contributors: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	contributors := dataset.Contributors(b.Role)
 	if len(b.Positions) != len(contributors) {
-		err := fmt.Errorf("positions don't match number of contributors")
-		c.Log.Warnw("order dataset contributors: could not order contributors", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(errors.New("positions don't match number of contributors")))
 		return
 	}
 	newContributors := make([]*models.Contributor, len(contributors))
@@ -606,8 +580,7 @@ func OrderContributors(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("order dataset contributors: Could not save the dataset:", "errors", err, "identifier", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/delete.go
+++ b/handlers/datasetediting/delete.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -29,7 +30,6 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	dataset := ctx.GetDataset(r)
 
 	if !c.User.CanDeleteDataset(dataset) {
-		c.Log.Warnw("delete dataset: user isn't allowed to delete dataset", "dataset", dataset.ID, "user", c.User.ID, "user", c.User.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -45,8 +45,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete dataset: Could not save the dataset:", "error", err, "identifier", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/department.go
+++ b/handlers/datasetediting/department.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -31,8 +32,7 @@ func AddDepartment(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := c.OrganizationSearchService.SuggestOrganizations("")
 	if err != nil {
-		c.Log.Errorw("add dataset department: could not suggest organization", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest organizations: %w", err)))
 		return
 	}
 
@@ -50,8 +50,7 @@ func SuggestDepartments(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := c.OrganizationSearchService.SuggestOrganizations(b.Query)
 	if err != nil {
-		c.Log.Errorw("add dataset department: could not suggest organization", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest organizations: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/details.go
+++ b/handlers/datasetediting/details.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -43,8 +44,7 @@ func RefreshEditDetails(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDetails{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset details: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -75,8 +75,7 @@ func UpdateDetails(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDetails{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset details: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -127,8 +126,7 @@ func UpdateDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update dataset details: Could not save the dataset:", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/link.go
+++ b/handlers/datasetediting/link.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -38,8 +39,7 @@ func CreateLink(w http.ResponseWriter, r *http.Request) {
 
 	b := BindLink{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("add dataset link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -71,8 +71,7 @@ func CreateLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("add dataset link: Could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -85,16 +84,14 @@ func EditLink(w http.ResponseWriter, r *http.Request) {
 
 	b := BindLink{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("edit dataset link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	// TODO catch non-existing item in UI
 	link := d.GetLink(b.LinkID)
 	if link == nil {
-		c.Log.Warnw("edit dataset link: could not get link", "link", b.LinkID, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(errors.New("could not get link")))
 		return
 	}
 
@@ -114,8 +111,7 @@ func UpdateLink(w http.ResponseWriter, r *http.Request) {
 
 	b := BindLink{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -153,8 +149,7 @@ func UpdateLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update dataset link: Could not save the dataset:", "errors", err, "identifier", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -167,8 +162,7 @@ func ConfirmDeleteLink(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteLink
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Errorw("confirm delete dataset link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -192,8 +186,7 @@ func DeleteLink(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteLink
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete dataset link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -208,8 +201,7 @@ func DeleteLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete dataset link: Could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/lock.go
+++ b/handlers/datasetediting/lock.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -36,8 +37,7 @@ func Lock(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("lock dataset: could not save the dataset:", "error", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -76,8 +76,7 @@ func Unlock(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("unlock dataset: could not save the dataset:", "error", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/project.go
+++ b/handlers/datasetediting/project.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -29,8 +30,7 @@ func AddProject(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := c.ProjectSearchService.SuggestProjects("")
 	if err != nil {
-		c.Log.Errorw("add dataset project: could not suggest projects:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest projects: %w", err)))
 		return
 	}
 
@@ -43,15 +43,13 @@ func SuggestProjects(w http.ResponseWriter, r *http.Request) {
 
 	b := BindSuggestProjects{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("suggest dataset project: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	hits, err := c.ProjectSearchService.SuggestProjects(b.Query)
 	if err != nil {
-		c.Log.Errorw("suggest dataset project: could not suggest projects:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest projects: %w", err)))
 		return
 	}
 
@@ -64,15 +62,13 @@ func CreateProject(w http.ResponseWriter, r *http.Request) {
 
 	b := BindProject{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("create dataset project: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	project, err := c.ProjectService.GetProject(b.ProjectID)
 	if err != nil {
-		c.Log.Errorw("create dataset project: could not get project:", "errors", err, "dataset", d.ID, "project", b.ProjectID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get project: %w", err)))
 		return
 	}
 
@@ -89,8 +85,7 @@ func CreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create dataset project: Could not save the dataset:", "errors", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 
@@ -103,8 +98,7 @@ func ConfirmDeleteProject(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteProject{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete dataset project: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -129,8 +123,7 @@ func DeleteProject(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteProject
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete dataset project: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -149,8 +142,7 @@ func DeleteProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete dataset project: Could not save the dataset:", "error", err, "dataset", d.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/publication.go
+++ b/handlers/datasetediting/publication.go
@@ -1,6 +1,7 @@
 package datasetediting
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -28,8 +29,7 @@ func AddPublication(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := searchRelatedPublications(c, dataset, "")
 	if err != nil {
-		c.Log.Errorf("add dataset publication: Could find related publications:", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could find related publications: %w", err)))
 		return
 	}
 
@@ -42,15 +42,13 @@ func SuggestPublications(w http.ResponseWriter, r *http.Request) {
 
 	b := BindSuggestPublications{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("suggest dataset publications: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	hits, err := searchRelatedPublications(c, dataset, b.Query)
 	if err != nil {
-		c.Log.Errorf("add dataset publication: Could find related publications:", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could find related publications: %w", err)))
 		return
 	}
 
@@ -63,16 +61,14 @@ func CreatePublication(w http.ResponseWriter, r *http.Request) {
 
 	b := BindPublication{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("create dataset publication: could not bind request arguments", "errors", err, "request", r)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	// TODO reduce calls to repository
 	p, err := c.Repo.GetPublication(b.PublicationID)
 	if err != nil {
-		c.Log.Errorw("create dataset publication: could not get the publication", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get the publications: %w", err)))
 		return
 	}
 
@@ -81,23 +77,20 @@ func CreatePublication(w http.ResponseWriter, r *http.Request) {
 	// TODO handle conflict
 	err = c.Repo.AddPublicationDataset(p, dataset, c.User)
 	if err != nil {
-		c.Log.Errorw("create dataset publication: could not add the publication", "error", err, "dataset", dataset.ID, "publication", p.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not add the publication: %w", err)))
 		return
 	}
 
 	// Refresh the ctx.Dataset: it still carries the old snapshotID
 	dataset, err = c.Repo.GetDataset(dataset.ID)
 	if err != nil {
-		c.Log.Errorw("create dataset publication: could not get dataset", "errors", err, "dataset", dataset.ID, "publication", b.PublicationID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get dataset: %w", err)))
 		return
 	}
 
 	relatedPublications, err := c.Repo.GetVisibleDatasetPublications(c.User, dataset)
 	if err != nil {
-		c.Log.Errorw("create dataset publication: could not get dataset publications", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get dataset publications: %w", err)))
 		return
 	}
 
@@ -110,8 +103,7 @@ func ConfirmDeletePublication(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeletePublication{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete dataset publication: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -134,16 +126,14 @@ func DeletePublication(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeletePublication{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete dataset publication: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	// TODO reduce calls to repository
 	p, err := c.Repo.GetPublication(b.PublicationID)
 	if err != nil {
-		c.Log.Errorw("delete dataset publication: could not get the publication", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get the publication: %w", err)))
 		return
 	}
 
@@ -153,23 +143,20 @@ func DeletePublication(w http.ResponseWriter, r *http.Request) {
 	err = c.Repo.RemovePublicationDataset(p, dataset, c.User)
 
 	if err != nil {
-		c.Log.Errorw("delete dataset publication: could not delete the publication", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not delete the publication: %w", err)))
 		return
 	}
 
 	// Refresh the dataset since it still caries the old snapshotid
 	dataset, err = c.Repo.GetDataset(dataset.ID)
 	if err != nil {
-		c.Log.Errorw("delete dataset publication: could not get the dataset", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get the dataset: %w", err)))
 		return
 	}
 
 	relatedPublications, err := c.Repo.GetVisibleDatasetPublications(c.User, dataset)
 	if err != nil {
-		c.Log.Errorw("create dataset publication: could not get dataset publications", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get dataset publications: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/publish.go
+++ b/handlers/datasetediting/publish.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -26,7 +27,6 @@ func Publish(w http.ResponseWriter, r *http.Request) {
 	dataset := ctx.GetDataset(r)
 
 	if !c.User.CanPublishDataset(dataset) {
-		c.Log.Warnw("publish dataset: user has no permission to publish", "dataset", dataset.ID, "user", c.User.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -51,8 +51,7 @@ func Publish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("publish dataset: could not save the dataset:", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/republish.go
+++ b/handlers/datasetediting/republish.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -26,7 +27,6 @@ func Republish(w http.ResponseWriter, r *http.Request) {
 	dataset := ctx.GetDataset(r)
 
 	if !c.User.CanPublishDataset(dataset) {
-		c.Log.Warnw("republish dataset: user has no permission to republish", "dataset", dataset.ID, "user", c.User.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -51,8 +51,7 @@ func Republish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("republish dataset: could not save the dataset:", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetediting/withdraw.go
+++ b/handlers/datasetediting/withdraw.go
@@ -2,6 +2,7 @@ package datasetediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -26,7 +27,6 @@ func Withdraw(w http.ResponseWriter, r *http.Request) {
 	dataset := ctx.GetDataset(r)
 
 	if !c.User.CanWithdrawDataset(dataset) {
-		c.Log.Warnw("withdraw dataset: user has no permission to withdraw", "dataset", dataset.ID, "user", c.User.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -51,8 +51,7 @@ func Withdraw(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("withdraw dataset: could not save the dataset:", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/datasetexporting/export.go
+++ b/handlers/datasetexporting/export.go
@@ -21,12 +21,6 @@ func ExportByCurationSearch(w http.ResponseWriter, r *http.Request) {
 
 	exporterFactory, exporterFactoryFound := c.DatasetListExporters[format]
 	if !exporterFactoryFound {
-		e := fmt.Errorf("unable to find exporter %s", format)
-		c.Log.Errorw(
-			"dataset search: could not find exporter",
-			"errors", e,
-			"user", c.User.ID,
-		)
 		c.HandleError(w, r, httperror.NotFound)
 		return
 	}
@@ -34,8 +28,7 @@ func ExportByCurationSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.Request(r, searchArgs); err != nil {
-		c.Log.Warnw("publication search: could not bind search arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, err)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -45,12 +38,7 @@ func ExportByCurationSearch(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if searcherErr != nil {
-		c.Log.Errorw(
-			"dataset search: unable to execute search",
-			"errors", searcherErr,
-			"user", c.User.ID,
-		)
-		c.HandleError(w, r, fmt.Errorf("unable to execute search: %w", searcherErr))
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("unable to execute search: %w", searcherErr)))
 		return
 	}
 
@@ -70,8 +58,7 @@ func ExportByCurationSearch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", contentDisposition)
 
 	if err := exporter.Flush(); err != nil {
-		c.Log.Errorw("dataset search: could not export search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, err)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not export search: %w", err)))
 		return
 	}
 

--- a/handlers/datasetsearching/search.go
+++ b/handlers/datasetsearching/search.go
@@ -27,8 +27,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.Request(r, searchArgs); err != nil {
-		c.Log.Warnw("dataset search: could not bind search arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(err))
 		return
 	}
 	searchArgs.Cleanup()
@@ -53,17 +52,14 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		searcher = searcher.WithScope("creator_id|author_id", c.User.ID)
 		currentScope = "all"
 	default:
-		errorUnkownScope := fmt.Errorf("unknown scope: %s", args.FilterFor("scope"))
-		c.Log.Warnw("dataset search: could not create searcher with passed filters", "errors", errorUnkownScope, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(fmt.Errorf("unknown scope: %s", args.FilterFor("scope"))))
 		return
 	}
 	delete(args.Filters, "scope")
 
 	hits, err := searcher.Search(args)
 	if err != nil {
-		c.Log.Errorw("dataset search: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -76,8 +72,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 	if hits.Total == 0 {
 		globalHits, globalHitsErr := globalSearch(searcher)
 		if globalHitsErr != nil {
-			c.Log.Errorw("publication search: could not execute global search", "errors", globalHitsErr, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute global search: %w", globalHitsErr)))
 			return
 		}
 		isFirstUse = globalHits.Total == 0
@@ -128,8 +123,7 @@ func CurationSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.Request(r, searchArgs); err != nil {
-		c.Log.Warnw("dataset search: could not bind search arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(err))
 		return
 	}
 	searchArgs.Cleanup()
@@ -139,8 +133,7 @@ func CurationSearch(w http.ResponseWriter, r *http.Request) {
 	searcher := c.DatasetSearchIndex.WithScope("status", "private", "public", "returned")
 	hits, err := searcher.Search(searchArgs)
 	if err != nil {
-		c.Log.Errorw("dataset search: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -153,8 +146,7 @@ func CurationSearch(w http.ResponseWriter, r *http.Request) {
 	if hits.Total == 0 {
 		globalHits, globalHitsErr := globalSearch(searcher)
 		if globalHitsErr != nil {
-			c.Log.Errorw("publication search: could not execute global search", "errors", globalHitsErr, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute global search: %w", globalHitsErr)))
 			return
 		}
 		isFirstUse = globalHits.Total == 0

--- a/handlers/datasetviewing/show.go
+++ b/handlers/datasetviewing/show.go
@@ -1,6 +1,7 @@
 package datasetviewing
 
 import (
+	"fmt"
 	"net/http"
 
 	"slices"
@@ -52,8 +53,7 @@ func ShowPublications(w http.ResponseWriter, r *http.Request) {
 
 	relatedPublications, err := c.Repo.GetVisibleDatasetPublications(c.User, dataset)
 	if err != nil {
-		c.Log.Errorw("show dataset publications: could not get publications", "errors", err, "dataset", dataset.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get publications: %w", err)))
 		return
 	}
 

--- a/handlers/impersonating/handler.go
+++ b/handlers/impersonating/handler.go
@@ -2,6 +2,7 @@ package impersonating
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -22,8 +23,7 @@ type BindCreateImpersonation struct {
 func AddImpersonation(w http.ResponseWriter, r *http.Request) {
 	c := ctx.Get(r)
 	if c.OriginalUser != nil {
-		c.Log.Warn("add impersonation: already impersonating", "user", c.OriginalUser.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(fmt.Errorf("already impersonating user %s", c.OriginalUser.ID)))
 		return
 	}
 
@@ -33,22 +33,19 @@ func AddImpersonation(w http.ResponseWriter, r *http.Request) {
 func AddImpersonationSuggest(w http.ResponseWriter, r *http.Request) {
 	c := ctx.Get(r)
 	if c.OriginalUser != nil {
-		c.Log.Warn("add impersonation: already impersonating", "user", c.OriginalUser.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(fmt.Errorf("already impersonating user %s", c.OriginalUser.ID)))
 		return
 	}
 
 	b := BindAddCImpersonationSuggest{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("suggest impersonation: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	hits, err := c.UserSearchService.SuggestUsers(b.FirstName + " " + b.LastName)
 	if err != nil {
-		c.Log.Errorw("suggest impersonation: could not suggest users:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest users: %w", err)))
 		return
 	}
 
@@ -70,22 +67,19 @@ func AddImpersonationSuggest(w http.ResponseWriter, r *http.Request) {
 func CreateImpersonation(w http.ResponseWriter, r *http.Request) {
 	c := ctx.Get(r)
 	if c.OriginalUser != nil {
-		c.Log.Warn("create impersonation: already impersonating", "user", c.OriginalUser.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(fmt.Errorf("already impersonating user %s", c.OriginalUser.ID)))
 		return
 	}
 
 	b := BindCreateImpersonation{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("create impersonation: could not bind request arguments", "errors", err, "request", r)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	user, err := c.UserService.GetUser(b.ID)
 	if err != nil {
-		c.Log.Errorf("create impersonation: unable to fetch user %s: %w", b.ID, err)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("unable to fetch user: %w", err)))
 		return
 	}
 
@@ -93,8 +87,7 @@ func CreateImpersonation(w http.ResponseWriter, r *http.Request) {
 
 	session, err := c.SessionStore.Get(r, c.SessionName)
 	if err != nil {
-		c.Log.Errorw("create impersonation: session could not be retrieved:", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("session could not be retrieved: %w", err)))
 		return
 	}
 
@@ -104,8 +97,7 @@ func CreateImpersonation(w http.ResponseWriter, r *http.Request) {
 	session.Values[ctx.UserRoleKey] = "user"
 
 	if err = session.Save(r, w); err != nil {
-		c.Log.Errorw("create impersonation: session could not be saved:", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("session could not be saved: %w", err)))
 		return
 	}
 
@@ -115,15 +107,13 @@ func CreateImpersonation(w http.ResponseWriter, r *http.Request) {
 func DeleteImpersonation(w http.ResponseWriter, r *http.Request) {
 	c := ctx.Get(r)
 	if c.OriginalUser == nil {
-		c.Log.Warnf("delete impersonation: %w", errors.New("no impersonation"))
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(errors.New("missing impersonation")))
 		return
 	}
 
 	session, err := c.SessionStore.Get(r, c.SessionName)
 	if err != nil {
-		c.Log.Errorw("delete impersonation: session could not be retrieved:", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("session could not be retrieved: %w", err)))
 		return
 	}
 
@@ -133,8 +123,7 @@ func DeleteImpersonation(w http.ResponseWriter, r *http.Request) {
 	delete(session.Values, ctx.OriginalUserRoleKey)
 
 	if err = session.Save(r, w); err != nil {
-		c.Log.Errorw("delete impersonation: session could not be saved:", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("session could not be saved: %w", err)))
 		return
 	}
 

--- a/handlers/mediatypes/handler.go
+++ b/handlers/mediatypes/handler.go
@@ -1,10 +1,12 @@
 package mediatypes
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
 	"github.com/ugent-library/biblio-backoffice/views/media_types"
+	"github.com/ugent-library/httperror"
 )
 
 func Suggest(w http.ResponseWriter, r *http.Request) {
@@ -19,8 +21,7 @@ func Suggest(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := c.Services.MediaTypeSearchService.SuggestMediaTypes(query)
 	if err != nil {
-		c.Log.Errorw("suggest mediatype: could not suggest mediatypes:", "errors", err, "query", query, "user", c.User.ID)
-		c.HandleError(w, r, err)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest mediatypes: %w", err)))
 		return
 	}
 

--- a/handlers/publicationcreating/import.go
+++ b/handlers/publicationcreating/import.go
@@ -53,8 +53,7 @@ func AddSingleImportConfirm(w http.ResponseWriter, r *http.Request) {
 
 	b := BindImportSingle{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("import confirm single publication: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -66,8 +65,7 @@ func AddSingleImportConfirm(w http.ResponseWriter, r *http.Request) {
 
 		existing, err := c.PublicationSearchIndex.Search(args)
 		if err != nil {
-			c.Log.Warnw("import single publication: could not execute search for duplicates", "errors", err, "args", args, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search for duplicates: %w", err)))
 			return
 		}
 
@@ -90,8 +88,7 @@ func AddSingleImport(w http.ResponseWriter, r *http.Request) {
 
 	b := BindImportSingle{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("import single publication: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -149,8 +146,7 @@ func AddSingleImport(w http.ResponseWriter, r *http.Request) {
 
 	err = c.Repo.SavePublication(p, c.User)
 	if err != nil {
-		c.Log.Errorf("import single publication: could not save the publication:", "error", err, "identifier", b.Identifier, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -197,7 +193,6 @@ func AddSinglePublish(w http.ResponseWriter, r *http.Request) {
 	publication := ctx.GetPublication(r)
 
 	if !c.User.CanPublishPublication(publication) {
-		c.Log.Warnw("add single publication publish: user has no permission to publish publication.", "publication", publication.ID, "user", c.User.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -219,8 +214,7 @@ func AddSinglePublish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("add single publication publish: could not save the publication:", "errors", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -249,8 +243,7 @@ func AddMultipleImport(w http.ResponseWriter, r *http.Request) {
 
 	file, _, err := r.FormFile("file")
 	if err != nil {
-		c.Log.Warnw("add multiple import publication: could not retrieve file from request", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(fmt.Errorf("could not retrieve file from request: %w", err)))
 		return
 	}
 	defer file.Close()
@@ -315,8 +308,7 @@ func AddMultipleConfirm(w http.ResponseWriter, r *http.Request) {
 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.Query(r, searchArgs); err != nil {
-		c.Log.Warnw("add multiple confirm publication: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -331,8 +323,7 @@ func AddMultipleConfirm(w http.ResponseWriter, r *http.Request) {
 		Search(searchArgs)
 
 	if err != nil {
-		c.Log.Errorw("add multiple confirm publication: could not execute search", "errors", err, "batch", batchID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -363,8 +354,7 @@ func AddMultiplePublish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorw("add multiple publish publication: could not publish publications", "errors", err, "batch", batchID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not publish publications: %w", err)))
 		return
 	}
 
@@ -377,8 +367,7 @@ func AddMultipleFinish(w http.ResponseWriter, r *http.Request) {
 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.Query(r, searchArgs); err != nil {
-		c.Log.Warnw("add multiple finish publication: could not bind request arguments", "errors", err, "request", r)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -393,8 +382,7 @@ func AddMultipleFinish(w http.ResponseWriter, r *http.Request) {
 		Search(searchArgs)
 
 	if err != nil {
-		c.Log.Errorw("add multiple finish publication: could not execute search", "errors", err, "batch", batchID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/abstract.go
+++ b/handlers/publicationediting/abstract.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -38,8 +39,7 @@ func CreateAbstract(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("create publication abstract: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -71,8 +71,7 @@ func CreateAbstract(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create publication abstract: could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -85,8 +84,7 @@ func EditAbstract(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("edit publication abstract: could not bind request arguments", "error", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -114,8 +112,7 @@ func UpdateAbstract(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAbstract{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication abstract: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -153,8 +150,7 @@ func UpdateAbstract(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication abstract: could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -167,8 +163,7 @@ func ConfirmDeleteAbstract(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteAbstract
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete publication abstract: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -191,8 +186,7 @@ func DeleteAbstract(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteAbstract
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete publication abstract: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -207,8 +201,7 @@ func DeleteAbstract(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create publication abstract: could not save the publication:", "error", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/activity.go
+++ b/handlers/publicationediting/activity.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -39,8 +40,7 @@ func UpdateMessage(w http.ResponseWriter, r *http.Request) {
 
 	b := BindMessage{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication reviewer note: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -69,8 +69,7 @@ func UpdateMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication message: could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -91,8 +90,7 @@ func UpdateReviewerTags(w http.ResponseWriter, r *http.Request) {
 
 	b := BindReviewerTags{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication reviewer tags: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -121,8 +119,7 @@ func UpdateReviewerTags(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication reviewer tags: could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -143,8 +140,7 @@ func UpdateReviewerNote(w http.ResponseWriter, r *http.Request) {
 
 	b := BindReviewerNote{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update dataset reviewer note: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -173,8 +169,7 @@ func UpdateReviewerNote(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update dataset reviewer note: could not save the dataset:", "errors", err, "dataset", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/additional_info.go
+++ b/handlers/publicationediting/additional_info.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -31,8 +32,7 @@ func UpdateAdditionalInfo(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAdditionalInfo{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication additional info: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -55,8 +55,7 @@ func UpdateAdditionalInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication additional info: could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/conference.go
+++ b/handlers/publicationediting/conference.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -33,8 +34,7 @@ func UpdateConference(w http.ResponseWriter, r *http.Request) {
 
 	b := BindConference{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication conference: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -58,8 +58,7 @@ func UpdateConference(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication conference: could not save the publication:", "error", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/contributors.go
+++ b/handlers/publicationediting/contributors.go
@@ -94,8 +94,7 @@ func AddContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAddContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("add publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -104,8 +103,7 @@ func AddContributor(w http.ResponseWriter, r *http.Request) {
 	if b.FirstName != "" || b.LastName != "" {
 		people, err := c.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
-			c.Log.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 			return
 		}
 		hits = make([]*models.Contributor, len(people))
@@ -131,8 +129,7 @@ func AddContributorSuggest(w http.ResponseWriter, r *http.Request) {
 
 	b := BindAddContributorSuggest{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("suggest publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -141,8 +138,7 @@ func AddContributorSuggest(w http.ResponseWriter, r *http.Request) {
 	if b.FirstName != "" || b.LastName != "" {
 		people, err := c.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
-			c.Log.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 			return
 		}
 		hits = make([]*models.Contributor, len(people))
@@ -167,8 +163,7 @@ func ConfirmCreateContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindConfirmCreateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("confirm create publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -197,8 +192,7 @@ func CreateContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindCreateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("create publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -242,8 +236,7 @@ func CreateContributor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create publication contributor: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -270,15 +263,13 @@ func EditContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindEditContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("edit publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	contributor, err := p.GetContributor(b.Role, b.Position)
 	if err != nil {
-		c.Log.Errorw("edit publication contributor: could not get the contributor", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get the contributor: %s", err)))
 		return
 	}
 
@@ -291,8 +282,7 @@ func EditContributor(w http.ResponseWriter, r *http.Request) {
 
 	people, err := c.PersonSearchService.SuggestPeople(firstName + " " + lastName)
 	if err != nil {
-		c.Log.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 		return
 	}
 
@@ -332,15 +322,13 @@ func EditContributorSuggest(w http.ResponseWriter, r *http.Request) {
 
 	b := BindEditContributorSuggest{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("suggest publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	contributor, err := p.GetContributor(b.Role, b.Position)
 	if err != nil {
-		c.Log.Errorw("edit publication contributor: could not get the contributor", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get the contributor: %w", err)))
 		return
 	}
 
@@ -349,8 +337,7 @@ func EditContributorSuggest(w http.ResponseWriter, r *http.Request) {
 	if b.FirstName != "" || b.LastName != "" {
 		people, err := c.PersonSearchService.SuggestPeople(b.FirstName + " " + b.LastName)
 		if err != nil {
-			c.Log.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 			return
 		}
 
@@ -387,15 +374,13 @@ func ConfirmUpdateContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindConfirmUpdateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("confirm update publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	oldC, err := p.GetContributor(b.Role, b.Position)
 	if err != nil {
-		c.Log.Errorw("edit publication contributor: could not get the contributor", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get the contributor: %w", err)))
 		return
 	}
 
@@ -428,8 +413,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindUpdateContributor{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -437,8 +421,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 	if b.ID != "" {
 		newContributor, err := generateContributorFromPersonId(c, b.ID)
 		if err != nil {
-			c.Log.Errorw("update publication contributor: could not fetch person", "errors", err, "personid", b.ID, "publication", p.ID, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not fetch person: %w", err)))
 			return
 		}
 		contributor = newContributor
@@ -454,8 +437,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 	contributor.CreditRole = b.CreditRole
 
 	if err := p.SetContributor(b.Role, b.Position, contributor); err != nil {
-		c.Log.Errorw("update publication contributor: could not set the contributor", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not set the contributor: %w", err)))
 		return
 	}
 
@@ -480,8 +462,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication contributor: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -490,8 +471,7 @@ func UpdateContributor(w http.ResponseWriter, r *http.Request) {
 		nextContributor := p.Contributors(b.Role)[nextPosition]
 		people, err := c.PersonSearchService.SuggestPeople(nextContributor.Name())
 		if err != nil {
-			c.Log.Errorw("suggest publication contributor: could not suggest people", "errors", err, "request", r, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest people: %w", err)))
 			return
 		}
 		hits := make([]*models.Contributor, len(people))
@@ -525,8 +505,7 @@ func ConfirmDeleteContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -543,16 +522,14 @@ func DeleteContributor(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteContributor{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete publication contributor: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	p := ctx.GetPublication(r)
 
 	if err := p.RemoveContributor(b.Role, b.Position); err != nil {
-		c.Log.Warnw("delete publication contributor: could not remove contributor", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not remove contributor: %w", err)))
 		return
 	}
 
@@ -571,8 +548,7 @@ func DeleteContributor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete publication contributor: Could not save the publication:", "error", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -585,16 +561,13 @@ func OrderContributors(w http.ResponseWriter, r *http.Request) {
 
 	b := BindOrderContributors{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("order publication contributors: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	contributors := p.Contributors(b.Role)
 	if len(b.Positions) != len(contributors) {
-		err := fmt.Errorf("positions don't match number of contributors")
-		c.Log.Warnw("order publication contributors: could not order contributors", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(errors.New("positions don't match number of contributors")))
 		return
 	}
 
@@ -615,8 +588,7 @@ func OrderContributors(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("order publication contributors: Could not save the publication:", "errors", err, "identifier", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/dataset.go
+++ b/handlers/publicationediting/dataset.go
@@ -1,6 +1,7 @@
 package publicationediting
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -29,8 +30,7 @@ func AddDataset(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := searchRelatedDatasets(c, p, "")
 	if err != nil {
-		c.Log.Errorw("add publication dataset: could not execute search", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -42,8 +42,7 @@ func SuggestDatasets(w http.ResponseWriter, r *http.Request) {
 
 	b := BindSuggestDatasets{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("suggest publication datasets: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -51,8 +50,7 @@ func SuggestDatasets(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := searchRelatedDatasets(c, p, b.Query)
 	if err != nil {
-		c.Log.Errorw("add publication dataset: could not execute search", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -65,16 +63,14 @@ func CreateDataset(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDataset{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("create publication dataset: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	// TODO reduce calls to repository
 	d, err := c.Repo.GetDataset(b.DatasetID)
 	if err != nil {
-		c.Log.Errorw("create publication dataset: could not get dataset", "errors", err, "publication", publication.ID, "dataset", b.DatasetID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get dataset: %w", err)))
 		return
 	}
 
@@ -83,23 +79,20 @@ func CreateDataset(w http.ResponseWriter, r *http.Request) {
 	// TODO handle conflict
 	err = c.Repo.AddPublicationDataset(publication, d, c.User)
 	if err != nil {
-		c.Log.Errorw("create publication dataset: could not add dataset to publication", "errors", err, "publication", publication.ID, "dataset", b.DatasetID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not add dataset to publication: %w", err)))
 		return
 	}
 
 	// Refresh the ctx.Publication: it still carries the old snapshotID
 	publication, err = c.Repo.GetPublication(publication.ID)
 	if err != nil {
-		c.Log.Errorw("create publication dataset: could not get publication", "errors", err, "publication", publication.ID, "dataset", b.DatasetID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get publication: %w", err)))
 		return
 	}
 
 	relatedDatasets, err := c.Repo.GetVisiblePublicationDatasets(c.User, publication)
 	if err != nil {
-		c.Log.Errorw("create publication dataset: could not get related datasets", "errors", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get related datasets: %w", err)))
 		return
 	}
 
@@ -112,8 +105,7 @@ func ConfirmDeleteDataset(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteDataset{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete publication dataset: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -136,8 +128,7 @@ func DeleteDataset(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteDataset{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete publication dataset: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -149,8 +140,7 @@ func DeleteDataset(w http.ResponseWriter, r *http.Request) {
 	// TODO reduce calls to repository
 	d, err := c.Repo.GetDataset(b.DatasetID)
 	if err != nil {
-		c.Log.Errorw("delete publication dataset: could not get dataset", "errors", err, "publication", publication.ID, "dataset", b.DatasetID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get dataset: %w", err)))
 		return
 	}
 
@@ -160,23 +150,20 @@ func DeleteDataset(w http.ResponseWriter, r *http.Request) {
 	err = c.Repo.RemovePublicationDataset(publication, d, c.User)
 
 	if err != nil {
-		c.Log.Errorw("delete publication dataset: could not remove dataset", "errors", err, "publication", publication.ID, "dataset", b.DatasetID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not remove dataset: %w", err)))
 		return
 	}
 
 	// Refresh the ctx.Publication: it still carries the old snapshotID
 	publication, err = c.Repo.GetPublication(publication.ID)
 	if err != nil {
-		c.Log.Errorw("delete publication dataset: could not get publication", "errors", err, "publication", publication.ID, "dataset", b.DatasetID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get publication: %w", err)))
 		return
 	}
 
 	relatedDatasets, err := c.Repo.GetVisiblePublicationDatasets(c.User, publication)
 	if err != nil {
-		c.Log.Errorw("create publication dataset: could not get related datasets", "errors", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get related datasets: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/delete.go
+++ b/handlers/publicationediting/delete.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -29,7 +30,6 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	publication := ctx.GetPublication(r)
 
 	if !c.User.CanDeletePublication(publication) {
-		c.Log.Warnw("delete publication: user is unauthorized", "publication", publication.ID, "user", c.User.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -48,8 +48,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete publication: Could not save the publication:", "errors", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/department.go
+++ b/handlers/publicationediting/department.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -31,8 +32,7 @@ func AddDepartment(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := c.OrganizationSearchService.SuggestOrganizations("")
 	if err != nil {
-		c.Log.Errorw("add publication department: could not suggest organization", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest organization: %w", err)))
 		return
 	}
 
@@ -44,15 +44,13 @@ func SuggestDepartments(w http.ResponseWriter, r *http.Request) {
 
 	b := BindSuggestDepartments{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("suggest publication departments could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	hits, err := c.OrganizationSearchService.SuggestOrganizations(b.Query)
 	if err != nil {
-		c.Log.Errorw("add publication department: could not suggest organization", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest organizations: %w", err)))
 		return
 	}
 
@@ -65,15 +63,13 @@ func CreateDepartment(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDepartment{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("create publication department: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	org, err := c.OrganizationService.GetOrganization(b.DepartmentID)
 	if err != nil {
-		c.Log.Errorw("create publication department: could not find organization", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not find organization: %w", err)))
 		return
 	}
 
@@ -90,8 +86,7 @@ func CreateDepartment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create publication department: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -104,8 +99,7 @@ func ConfirmDeleteDepartment(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteDepartment{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete publication department: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -132,8 +126,7 @@ func DeleteDepartment(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteDepartment
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete publication department: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -154,8 +147,7 @@ func DeleteDepartment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete publication department: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/details.go
+++ b/handlers/publicationediting/details.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -69,8 +70,7 @@ func UpdateDetails(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDetails
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication details: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -135,8 +135,7 @@ func UpdateDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication details: Could not save the publication:", "error", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/files.go
+++ b/handlers/publicationediting/files.go
@@ -67,9 +67,8 @@ func UploadFile(w http.ResponseWriter, r *http.Request) {
 
 	maxBytesErr := &http.MaxBytesError{}
 	if errors.As(err, &maxBytesErr) {
-		c.Log.Errorf("publication upload file: could not save file", "errors", err, "publication", p.ID, "user", c.User.ID)
 		// TODO show friendly error
-		http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+		c.HandleError(w, r, httperror.RequestEntityTooLarge.Wrap(fmt.Errorf("could not save file: %w", maxBytesErr)))
 		return
 	}
 
@@ -143,8 +142,7 @@ func RefreshEditFileForm(w http.ResponseWriter, r *http.Request) {
 
 	var b BindFile
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("edit publication file license: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -195,8 +193,7 @@ func UpdateFile(w http.ResponseWriter, r *http.Request) {
 
 	b := BindFile{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("update publication file: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -253,8 +250,7 @@ func UpdateFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication file: could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -267,8 +263,7 @@ func ConfirmDeleteFile(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteFile
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete publication file: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -293,8 +288,7 @@ func DeleteFile(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteFile
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete publication file: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -309,8 +303,7 @@ func DeleteFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete publication file: could not save the publication:", "error", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/lay_summary.go
+++ b/handlers/publicationediting/lay_summary.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -38,8 +39,7 @@ func CreateLaySummary(w http.ResponseWriter, r *http.Request) {
 
 	var b BindLaySummary
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("create publication lay summary: could not bind request arguments", "error", err, "request", r)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -71,8 +71,7 @@ func CreateLaySummary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create publication lay summary: Could not save the publication:", "error", err, "publication", p.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -85,8 +84,7 @@ func EditLaySummary(w http.ResponseWriter, r *http.Request) {
 
 	var b BindLaySummary
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("edit publication lay summary: could not bind request arguments", "error", err, "request", r)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -115,8 +113,7 @@ func UpdateLaySummary(w http.ResponseWriter, r *http.Request) {
 
 	b := BindLaySummary{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication lay summary: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -157,8 +154,7 @@ func UpdateLaySummary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication lay summary: Could not save the publication:", "error", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -171,8 +167,7 @@ func ConfirmDeleteLaySummary(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteLaySummary
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete publication lay summary: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -195,8 +190,7 @@ func DeleteLaySummary(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteLaySummary
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete publication lay summary: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -211,8 +205,7 @@ func DeleteLaySummary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete publication lay summary: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/link.go
+++ b/handlers/publicationediting/link.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -39,8 +40,7 @@ func CreateLink(w http.ResponseWriter, r *http.Request) {
 
 	b := BindLink{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("add publication link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -71,8 +71,7 @@ func CreateLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("add publication link: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -85,8 +84,7 @@ func EditLink(w http.ResponseWriter, r *http.Request) {
 
 	b := BindLink{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("edit publication link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -113,8 +111,7 @@ func UpdateLink(w http.ResponseWriter, r *http.Request) {
 
 	b := BindLink{}
 	if err := bind.Request(r, &b, bind.Vacuum); err != nil {
-		c.Log.Warnw("update publication link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -152,8 +149,7 @@ func UpdateLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication link: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -166,8 +162,7 @@ func ConfirmDeleteLink(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteLink
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Errorw("confirm delete publication link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -191,8 +186,7 @@ func DeleteLink(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteLink
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete publication link: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -207,8 +201,7 @@ func DeleteLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete publication link: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/lock.go
+++ b/handlers/publicationediting/lock.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -36,8 +37,7 @@ func Lock(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("lock publication: could not save the publication:", "error", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -76,8 +76,7 @@ func Unlock(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("unlock publication: could not save the publication:", "error", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/project.go
+++ b/handlers/publicationediting/project.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -29,8 +30,7 @@ func AddProject(w http.ResponseWriter, r *http.Request) {
 
 	hits, err := c.ProjectSearchService.SuggestProjects("")
 	if err != nil {
-		c.Log.Errorw("add publication project: could not suggest projects:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest projects: %w", err)))
 		return
 	}
 
@@ -42,15 +42,13 @@ func SuggestProjects(w http.ResponseWriter, r *http.Request) {
 
 	b := BindSuggestProjects{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("suggest publication project: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	hits, err := c.ProjectSearchService.SuggestProjects(b.Query)
 	if err != nil {
-		c.Log.Errorw("suggest publication project: could not suggest projects:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not suggest projects: %w", err)))
 		return
 	}
 
@@ -63,15 +61,13 @@ func CreateProject(w http.ResponseWriter, r *http.Request) {
 
 	b := BindProject{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("create publication project: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
 	project, err := c.ProjectService.GetProject(b.ProjectID)
 	if err != nil {
-		c.Log.Errorw("create publication project: could not get project:", "errors", err, "publication", p.ID, "project", b.ProjectID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get project: %w", err)))
 		return
 	}
 	p.AddProject(project)
@@ -87,8 +83,7 @@ func CreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("create publication project: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 
@@ -101,8 +96,7 @@ func ConfirmDeleteProject(w http.ResponseWriter, r *http.Request) {
 
 	b := BindDeleteProject{}
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("confirm delete publication project: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -127,8 +121,7 @@ func DeleteProject(w http.ResponseWriter, r *http.Request) {
 
 	var b BindDeleteProject
 	if err := bind.Request(r, &b); err != nil {
-		c.Log.Warnw("delete publication project: could not bind request arguments:", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -147,8 +140,7 @@ func DeleteProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("delete publication project: Could not save the publication:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/publish.go
+++ b/handlers/publicationediting/publish.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -26,7 +27,6 @@ func Publish(w http.ResponseWriter, r *http.Request) {
 	publication := ctx.GetPublication(r)
 
 	if !c.User.CanEditPublication(publication) {
-		c.Log.Warnw("publish dataset: user has no permission to publish", "user", c.User.ID, "publication", publication.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -51,8 +51,7 @@ func Publish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("publish dataset: could not save the dataset:", "error", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the dataset: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/republish.go
+++ b/handlers/publicationediting/republish.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -26,7 +27,6 @@ func Republish(w http.ResponseWriter, r *http.Request) {
 	publication := ctx.GetPublication(r)
 
 	if !c.User.CanPublishPublication(publication) {
-		c.Log.Warnw("republish publication: user has no permission to republish", "user", c.User.ID, "publication", publication.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -51,8 +51,7 @@ func Republish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("republish publication: could not save the publication:", "error", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/type.go
+++ b/handlers/publicationediting/type.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -30,8 +31,7 @@ func UpdateType(w http.ResponseWriter, r *http.Request) {
 
 	b := BindType{}
 	if err := bind.Body(r, &b); err != nil {
-		c.Log.Warnw("update publication type: could not bind request arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 
@@ -51,8 +51,7 @@ func UpdateType(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("update publication type: Could not save the publication:", "error", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationediting/withdraw.go
+++ b/handlers/publicationediting/withdraw.go
@@ -2,6 +2,7 @@ package publicationediting
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -26,7 +27,6 @@ func Withdraw(w http.ResponseWriter, r *http.Request) {
 	publication := ctx.GetPublication(r)
 
 	if !c.User.CanWithdrawPublication(publication) {
-		c.Log.Warnw("witdraw publication: user has no permission to withdraw", "user", c.User.ID, "publication", publication.ID)
 		c.HandleError(w, r, httperror.Forbidden)
 		return
 	}
@@ -51,8 +51,7 @@ func Withdraw(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		c.Log.Errorf("withdraw publication: could not save the publication:", "error", err, "publication", publication.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not save the publication: %w", err)))
 		return
 	}
 

--- a/handlers/publicationsearching/search.go
+++ b/handlers/publicationsearching/search.go
@@ -27,8 +27,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.Request(r, searchArgs); err != nil {
-		c.Log.Warnw("publication search: could not bind search arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 	searchArgs.Cleanup()
@@ -53,17 +52,14 @@ func Search(w http.ResponseWriter, r *http.Request) {
 		searcher = searcher.WithScope("creator_id|author_id", c.User.ID)
 		currentScope = "all"
 	default:
-		errorUnkownScope := fmt.Errorf("unknown scope: %s", args.FilterFor("scope"))
-		c.Log.Warnw("publication search: could not create searcher with passed filters", "errors", errorUnkownScope, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(fmt.Errorf("unknown scope: %s", args.FilterFor("scope"))))
 		return
 	}
 	delete(args.Filters, "scope")
 
 	hits, err := searcher.Search(args)
 	if err != nil {
-		c.Log.Errorw("publication search: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -76,8 +72,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 	if hits.Total == 0 {
 		globalHits, globalHitsErr := globalSearch(searcher)
 		if globalHitsErr != nil {
-			c.Log.Errorw("publication search: could not execute global search", "errors", globalHitsErr, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute global search: %w", globalHitsErr)))
 			return
 		}
 		isFirstUse = globalHits.Total == 0
@@ -127,8 +122,7 @@ func CurationSearch(w http.ResponseWriter, r *http.Request) {
 
 	searchArgs := models.NewSearchArgs()
 	if err := bind.Request(r, searchArgs); err != nil {
-		c.Log.Warnw("publication search: could not bind search arguments", "errors", err, "request", r, "user", c.User.ID)
-		c.HandleError(w, r, httperror.BadRequest)
+		c.HandleError(w, r, httperror.BadRequest.Wrap(err))
 		return
 	}
 	searchArgs.Cleanup()
@@ -138,8 +132,7 @@ func CurationSearch(w http.ResponseWriter, r *http.Request) {
 	searcher := c.PublicationSearchIndex.WithScope("status", "private", "public", "returned")
 	hits, err := searcher.Search(searchArgs)
 	if err != nil {
-		c.Log.Errorw("publication search: could not execute search", "errors", err, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute search: %w", err)))
 		return
 	}
 
@@ -152,8 +145,7 @@ func CurationSearch(w http.ResponseWriter, r *http.Request) {
 	if hits.Total == 0 {
 		globalHits, globalHitsErr := globalSearch(searcher)
 		if globalHitsErr != nil {
-			c.Log.Errorw("curation publication search: could not execute global search", "errors", globalHitsErr, "user", c.User.ID)
-			c.HandleError(w, r, httperror.InternalServerError)
+			c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not execute global search: %w", globalHitsErr)))
 			return
 		}
 		isFirstUse = globalHits.Total == 0

--- a/handlers/publicationviewing/show.go
+++ b/handlers/publicationviewing/show.go
@@ -1,6 +1,7 @@
 package publicationviewing
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ugent-library/biblio-backoffice/ctx"
@@ -68,8 +69,7 @@ func ShowDatasets(w http.ResponseWriter, r *http.Request) {
 
 	datasets, err := c.Repo.GetVisiblePublicationDatasets(c.User, p)
 	if err != nil {
-		c.Log.Warn("show publication datasets: could not get publication datasets:", "errors", err, "publication", p.ID, "user", c.User.ID)
-		c.HandleError(w, r, httperror.InternalServerError)
+		c.HandleError(w, r, httperror.InternalServerError.Wrap(fmt.Errorf("could not get publication datasets: %w", err)))
 		return
 	}
 


### PR DESCRIPTION
fixes #1579

Notes:

* I included the custom error message from the old `c.Log` into the wrapped error, but for errors with  `bind.Request` I merely wrapped the error without `Could not bind arguments`. 