### PR TITLE
Some small fixes to for field labels

### DIFF
--- a/views/search.templ
+++ b/views/search.templ
@@ -243,7 +243,7 @@ templ Query(c *ctx.Ctx, searchArgs *models.SearchArgs) {
 			<div class="col">
 				<div class="input-group flex-nowrap">
 					<label class="visually-hidden" for="q">Search</label>
-					<input class="form-control" type="text" name="q" value={ searchArgs.Query } placeholder="Search..." autocomplete="off"/>
+					<input class="form-control" type="text" id="q" name="q" value={ searchArgs.Query } placeholder="Search..." autocomplete="off"/>
 					<button type="submit" class="btn btn-outline-primary" type="button">
 						<i class="if if-search"></i>
 						<span class="btn-text">Search</span>

--- a/views/search.templ
+++ b/views/search.templ
@@ -151,8 +151,8 @@ templ FacetSince(c *ctx.Ctx, fieldName string, title string, description string,
 				</div>
 			</div>
 			<div class="dropdown-menu__body">
-				<label class="col-form-label">{ description }</label>
-				<input class="form-control" type="text" name={ fmt.Sprintf("f[%s]", fieldName) } value={ searchArgs.FilterFor(fieldName) }/>
+				<label class="col-form-label" for={ fmt.Sprintf("f-%s-", fieldName) }>{ description }</label>
+				<input class="form-control" type="text" id={ fmt.Sprintf("f-%s-", fieldName) } name={ fmt.Sprintf("f[%s]", fieldName) } value={ searchArgs.FilterFor(fieldName) }/>
 				<small class="form-text text-muted">Type a date (YYYY-MM-DD), year (YYYY) or timing (today, yesterday).</small>
 			</div>
 			<div class="bc-navbar bc-navbar--large">

--- a/views/search.templ
+++ b/views/search.templ
@@ -151,8 +151,8 @@ templ FacetSince(c *ctx.Ctx, fieldName string, title string, description string,
 				</div>
 			</div>
 			<div class="dropdown-menu__body">
-				<label class="col-form-label" for={ fmt.Sprintf("f-%s-", fieldName) }>{ description }</label>
-				<input class="form-control" type="text" id={ fmt.Sprintf("f-%s-", fieldName) } name={ fmt.Sprintf("f[%s]", fieldName) } value={ searchArgs.FilterFor(fieldName) }/>
+				<label class="col-form-label" for={ fmt.Sprintf("f-%s", fieldName) }>{ description }</label>
+				<input class="form-control" type="text" id={ fmt.Sprintf("f-%s", fieldName) } name={ fmt.Sprintf("f[%s]", fieldName) } value={ searchArgs.FilterFor(fieldName) }/>
 				<small class="form-text text-muted">Type a date (YYYY-MM-DD), year (YYYY) or timing (today, yesterday).</small>
 			</div>
 			<div class="bc-navbar bc-navbar--large">

--- a/views/search_templ.go
+++ b/views/search_templ.go
@@ -402,20 +402,36 @@ func FacetSince(c *ctx.Ctx, fieldName string, title string, description string, 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</h4></div></div></div><div class=\"dropdown-menu__body\"><label class=\"col-form-label\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</h4></div></div></div><div class=\"dropdown-menu__body\"><label class=\"col-form-label\" for=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(fmt.Sprintf("f-%s-", fieldName)))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `search.templ`, Line: 153, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `search.templ`, Line: 153, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</label> <input class=\"form-control\" type=\"text\" name=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</label> <input class=\"form-control\" type=\"text\" id=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(fmt.Sprintf("f-%s-", fieldName)))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/views/search_templ.go
+++ b/views/search_templ.go
@@ -676,7 +676,7 @@ func Query(c *ctx.Ctx, searchArgs *models.SearchArgs) templ.Component {
 				}
 			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"row\"><div class=\"col\"><div class=\"input-group flex-nowrap\"><label class=\"visually-hidden\" for=\"q\">Search</label> <input class=\"form-control\" type=\"text\" name=\"q\" value=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"row\"><div class=\"col\"><div class=\"input-group flex-nowrap\"><label class=\"visually-hidden\" for=\"q\">Search</label> <input class=\"form-control\" type=\"text\" id=\"q\" name=\"q\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/views/search_templ.go
+++ b/views/search_templ.go
@@ -406,7 +406,7 @@ func FacetSince(c *ctx.Ctx, fieldName string, title string, description string, 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(fmt.Sprintf("f-%s-", fieldName)))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(fmt.Sprintf("f-%s", fieldName)))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -417,7 +417,7 @@ func FacetSince(c *ctx.Ctx, fieldName string, title string, description string, 
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `search.templ`, Line: 153, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `search.templ`, Line: 153, Col: 86}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -427,7 +427,7 @@ func FacetSince(c *ctx.Ctx, fieldName string, title string, description string, 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(fmt.Sprintf("f-%s-", fieldName)))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(fmt.Sprintf("f-%s", fieldName)))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
This PR fixes a few labels that were not attached to their corresponding fields:

* The hidden (screen reader only) label next to the search query field in all overviews
* The created/updated since facet filter fields