### PR TITLE
Nil reference bugfix in dataset project list when EUProject is nil

### DIFF
--- a/views/dataset/projects.templ
+++ b/views/dataset/projects.templ
@@ -82,21 +82,19 @@ templ ProjectsBody(c *ctx.Ctx, dataset *models.Dataset) {
 											</li>
 										</ul>
 										<ul class="c-meta-list mb-2">
-											<li class="c-meta-item">
-												<div class="pe-4 me-3 border-right">
+											<li class="c-meta-item gap-4">
+												<div>
 													<span>Project ID</span>
 													<code class="c-code d-inline-block">{ rel.Project.ID }</code>
 												</div>
 												if rel.Project.IWETOID != "" {
-													<div
-														class={ "pe-4", "me-3", templ.KV("border-right", rel.Project.EUProject.ID != "") }
-													>
+													<div class="ps-4 border-left">
 														<span>IWETO ID</span>
 														<code class="c-code d-inline-block">{ rel.Project.IWETOID }</code>
 													</div>
 												}
 												if rel.Project.EUProject != nil && rel.Project.EUProject.ID != "" {
-													<div class="me-3">
+													<div class="ps-4 border-left">
 														<span>CORDIS ID</span>
 														<code class="c-code d-inline-block">{ rel.Project.EUProject.ID }</code>
 													</div>

--- a/views/dataset/projects_templ.go
+++ b/views/dataset/projects_templ.go
@@ -198,7 +198,7 @@ func ProjectsBody(c *ctx.Ctx, dataset *models.Dataset) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" target=\"blank\">Read more <i class=\"if if-external-link if--small\"></i></a></div></li></ul><ul class=\"c-meta-list mb-2\"><li class=\"c-meta-item\"><div class=\"pe-4 me-3 border-right\"><span>Project ID</span> <code class=\"c-code d-inline-block\">")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" target=\"blank\">Read more <i class=\"if if-external-link if--small\"></i></a></div></li></ul><ul class=\"c-meta-list mb-2\"><li class=\"c-meta-item gap-4\"><div><span>Project ID</span> <code class=\"c-code d-inline-block\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -216,29 +216,16 @@ func ProjectsBody(c *ctx.Ctx, dataset *models.Dataset) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				if rel.Project.IWETOID != "" {
-					var templ_7745c5c3_Var10 = []any{"pe-4", "me-3", templ.KV("border-right", rel.Project.EUProject.ID != "")}
-					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var10...)
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"ps-4 border-left\"><span>IWETO ID</span> <code class=\"c-code d-inline-block\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"")
+					var templ_7745c5c3_Var10 string
+					templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(rel.Project.IWETOID)
 					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/projects.templ`, Line: 92, Col: 71}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ.CSSClasses(templ_7745c5c3_Var10).String()))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\"><span>IWETO ID</span> <code class=\"c-code d-inline-block\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var11 string
-					templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(rel.Project.IWETOID)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/projects.templ`, Line: 94, Col: 71}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -248,16 +235,16 @@ func ProjectsBody(c *ctx.Ctx, dataset *models.Dataset) templ.Component {
 					}
 				}
 				if rel.Project.EUProject != nil && rel.Project.EUProject.ID != "" {
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"me-3\"><span>CORDIS ID</span> <code class=\"c-code d-inline-block\">")
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"ps-4 border-left\"><span>CORDIS ID</span> <code class=\"c-code d-inline-block\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var12 string
-					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(rel.Project.EUProject.ID)
+					var templ_7745c5c3_Var11 string
+					templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(rel.Project.EUProject.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/projects.templ`, Line: 100, Col: 76}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/projects.templ`, Line: 98, Col: 76}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}

--- a/views/publication/projects.templ
+++ b/views/publication/projects.templ
@@ -78,19 +78,19 @@ templ ProjectsBody(c *ctx.Ctx, p *models.Publication) {
 											</li>
 										</ul>
 										<ul class="c-meta-list mb-2">
-											<li class="c-meta-item">
-												<div class="pe-4 me-3 border-right">
+											<li class="c-meta-item gap-4">
+												<div>
 													<span>Project ID</span>
 													<code class="c-code d-inline-block">{ rel.Project.ID }</code>
 												</div>
 												if rel.Project.IWETOID != "" {
-													<div class={ "pe-4", "me-3", templ.KV("border-right", rel.Project.EUProject != nil && rel.Project.EUProject.ID != "") }>
+													<div class="ps-4 border-left">
 														<span>IWETO ID</span>
 														<code class="c-code d-inline-block">{ rel.Project.IWETOID }</code>
 													</div>
 												}
 												if rel.Project.EUProject != nil && rel.Project.EUProject.ID != "" {
-													<div class="me-3">
+													<div class="ps-4 border-left">
 														<span>CORDIS ID</span>
 														<code class="c-code d-inline-block">{ rel.Project.EUProject.ID }</code>
 													</div>

--- a/views/publication/projects_templ.go
+++ b/views/publication/projects_templ.go
@@ -200,7 +200,7 @@ func ProjectsBody(c *ctx.Ctx, p *models.Publication) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" target=\"blank\">Read more <i class=\"if if-external-link if--small\"></i></a></div></li></ul><ul class=\"c-meta-list mb-2\"><li class=\"c-meta-item\"><div class=\"pe-4 me-3 border-right\"><span>Project ID</span> <code class=\"c-code d-inline-block\">")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" target=\"blank\">Read more <i class=\"if if-external-link if--small\"></i></a></div></li></ul><ul class=\"c-meta-list mb-2\"><li class=\"c-meta-item gap-4\"><div><span>Project ID</span> <code class=\"c-code d-inline-block\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -218,29 +218,16 @@ func ProjectsBody(c *ctx.Ctx, p *models.Publication) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				if rel.Project.IWETOID != "" {
-					var templ_7745c5c3_Var10 = []any{"pe-4", "me-3", templ.KV("border-right", rel.Project.EUProject != nil && rel.Project.EUProject.ID != "")}
-					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var10...)
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"ps-4 border-left\"><span>IWETO ID</span> <code class=\"c-code d-inline-block\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ.CSSClasses(templ_7745c5c3_Var10).String()))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\"><span>IWETO ID</span> <code class=\"c-code d-inline-block\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var11 string
-					templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(rel.Project.IWETOID)
+					var templ_7745c5c3_Var10 string
+					templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(rel.Project.IWETOID)
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/projects.templ`, Line: 88, Col: 71}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -250,16 +237,16 @@ func ProjectsBody(c *ctx.Ctx, p *models.Publication) templ.Component {
 					}
 				}
 				if rel.Project.EUProject != nil && rel.Project.EUProject.ID != "" {
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"me-3\"><span>CORDIS ID</span> <code class=\"c-code d-inline-block\">")
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"ps-4 border-left\"><span>CORDIS ID</span> <code class=\"c-code d-inline-block\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var12 string
-					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(rel.Project.EUProject.ID)
+					var templ_7745c5c3_Var11 string
+					templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(rel.Project.EUProject.ID)
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/projects.templ`, Line: 94, Col: 76}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}


### PR DESCRIPTION
Editing a dataset was broken when an attached project was not linked to an EUProject. Only found out now since my projects test data changed.

If the bug is already in production, this needs to be patched asap.