### PR TITLE
Fixes #1626: adds language support when importing Bibtex records.

### DIFF
--- a/backends/bibtex/decoder.go
+++ b/backends/bibtex/decoder.go
@@ -150,4 +150,72 @@ func mapEntry(e *bibtex.Entry, p *models.Publication) {
 			p.WOSID = strings.TrimPrefix(f, "ISI:")
 		}
 	}
+
+	// WOS language
+	if f, ok := fields["language"]; ok {
+		if lang, ok := wosLangs[f]; ok {
+			p.Language = []string{lang}
+		}
+	}
+}
+
+// Mapping between value in WOS Bibtex Language field and ISO-396-2
+// code is made based on https://www.loc.gov/standards/iso639-2/php/code_list.php
+// Languages which differentiate between a bibliographic and terminology code,
+// preference was given to the B code.
+// WOS Language list: https://images.webofknowledge.com/images/help/WOS/hs_language.html
+var wosLangs = map[string]string{
+	"English":        "eng",
+	"Afrikaans":      "afr",
+	"Arabic":         "ara",
+	"Basque":         "baq",
+	"Bengali":        "ben",
+	"Bulgarian":      "bul",
+	"Byelorussian":   "bel",
+	"Catalan":        "cat",
+	"Chinese":        "chi",
+	"Croatian":       "hrv",
+	"Czech":          "cze",
+	"Danish":         "dan",
+	"Dutch":          "dut",
+	"Estonian":       "est",
+	"Finnish":        "fin",
+	"Flemish":        "dut",
+	"French":         "fre",
+	"Gaelic":         "gla",
+	"Galician":       "glg",
+	"Georgian":       "geo",
+	"German":         "ger",
+	"Greek":          "gre",
+	"Hebrew":         "heb",
+	"Hungarian":      "hun",
+	"Icelandic":      "ice",
+	"Italian":        "ita",
+	"Japanese":       "jpn",
+	"Korean":         "kor",
+	"Latin":          "lat",
+	"Latvian":        "lav",
+	"Lithuanian":     "lit",
+	"Macedonian":     "mac",
+	"Malay":          "may",
+	"Multi-Language": "mul",
+	"Norwegian":      "nor",
+	"Persian":        "per",
+	"Polish":         "pol",
+	"Portuguese":     "por",
+	"Provencal":      "pro",
+	"Romansch":       "roh",
+	"Rumanian":       "rup",
+	"Russian":        "rus",
+	"Serbian":        "srp",
+	// "Serbo-Croatian": "" not supported in ISO 369-2
+	"Slovak":      "slo",
+	"Slovenian":   "slv",
+	"Spanish":     "spa",
+	"Swedish":     "swe",
+	"Thai":        "tha",
+	"Turkish":     "tur",
+	"Ukrainian":   "ukr",
+	"Unspecified": "und",
+	"Welsh":       "wel",
 }


### PR DESCRIPTION
Refs #1626 

The Bibtex `Language` field does not contain a standardized language code (e.g. ISO-369 or BCP47 code): it contains the human name / label of the language (e.g. English, Flemish, Dutch, French,...). This is problematic because of potential ambiguity.

This commit contains a manually made mapping between those labels to the ISO-396-2 code based on: (a) this table published by Library of Congress (https://www.loc.gov/standards/iso639-2/php/code_list.php) and (b) the ISO-369-2 language codes we use in the application.

Moreover, the WOS list isn't exhaustive. They may decide to add new languages without updating the documentation (https://images.webofknowledge.com/images/help/WOS/hs_language.html). e.g. "Romansch" isn't included, but I found records with that language in WOS. It's nearly impossible to account for all potential labels of all existing languages in the world.

So, this way of handling languages comes with caveats.

The other option is to not include this; and let researchers / curators add the language manually. 