### PR TITLE
Fix/various UI fixes

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile
     env_file:
@@ -48,7 +48,7 @@ services:
       timeout: 10s
       retries: 5
 
-  # NOTE: Elastic 6.8 doesn't provide an arm64 image. So, we need to use a 
+  # NOTE: Elastic 6.8 doesn't provide an arm64 image. So, we need to use a
   # custom image for the time being. Switch to the container below if you are on x86_64.
 
   # es:

--- a/views/contributor/summary.templ
+++ b/views/contributor/summary.templ
@@ -64,7 +64,7 @@ templ Summary(c *ctx.Ctx, args SummaryArgs) {
 			</div>
 		}
 		if args.CurrentUserRoles != "" {
-			<div class="c-author"><span class="badge rounded-pill badge-light">Your role: { args.CurrentUserRoles }</span></div>
+			<div class="c-author"><span class="badge badge-light">Your role: { args.CurrentUserRoles }</span></div>
 		}
 	</div>
 }

--- a/views/contributor/summary_templ.go
+++ b/views/contributor/summary_templ.go
@@ -203,14 +203,14 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 			}
 		}
 		if args.CurrentUserRoles != "" {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"c-author\"><span class=\"badge rounded-pill badge-light\">Your role: ")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"c-author\"><span class=\"badge badge-light\">Your role: ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(args.CurrentUserRoles)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `contributor/summary.templ`, Line: 66, Col: 104}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `contributor/summary.templ`, Line: 66, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {

--- a/views/dataset/search_hit.templ
+++ b/views/dataset/search_hit.templ
@@ -15,11 +15,10 @@ templ SummaryActions(c *ctx.Ctx, dataset *models.Dataset, url string) {
 				<span class="visually-hidden">View more actions</span>
 			</button>
 			<div class="dropdown-menu me-3">
-				<a class="dropdown-item" href={ templ.URL(url) }>
+				<a class="dropdown-item border-bottom" href={ templ.URL(url) }>
 					<i class="if if-eye"></i>
 					<span>View dataset</span>
 				</a>
-				<div class="dropdown-divider"></div>
 				if dataset.Status == "public" {
 					<a class="dropdown-item" href={ templ.URL(fmt.Sprintf("%s/publication/%s", c.FrontendURL, dataset.ID)) } target="_blank">
 						<i class="if if-book"></i>
@@ -33,9 +32,8 @@ templ SummaryActions(c *ctx.Ctx, dataset *models.Dataset, url string) {
 					</a>
 				}
 				if c.User.CanDeleteDataset(dataset) {
-					<div class="dropdown-divider"></div>
 					<button
-						class="dropdown-item"
+						class="dropdown-item border-top"
 						hx-get={ views.URL(c.PathTo("dataset_confirm_delete", "id", dataset.ID)).AddQueryParam("redirect-url", c.CurrentURL.String()).String() }
 						hx-target="#modals"
 					>

--- a/views/dataset/search_hit_templ.go
+++ b/views/dataset/search_hit_templ.go
@@ -29,7 +29,7 @@ func SummaryActions(c *ctx.Ctx, dataset *models.Dataset, url string) templ.Compo
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"c-button-toolbar\"><div class=\"dropdown\"><button class=\"btn btn-tertiary btn-lg-only-responsive pt-0\" type=\"button\" data-bs-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"><i class=\"if if-more\"></i> <span class=\"btn-text d-md-none d-lg-inline-block\">Actions</span> <span class=\"visually-hidden\">View more actions</span></button><div class=\"dropdown-menu me-3\"><a class=\"dropdown-item\" href=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"c-button-toolbar\"><div class=\"dropdown\"><button class=\"btn btn-tertiary btn-lg-only-responsive pt-0\" type=\"button\" data-bs-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"><i class=\"if if-more\"></i> <span class=\"btn-text d-md-none d-lg-inline-block\">Actions</span> <span class=\"visually-hidden\">View more actions</span></button><div class=\"dropdown-menu me-3\"><a class=\"dropdown-item border-bottom\" href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -38,7 +38,7 @@ func SummaryActions(c *ctx.Ctx, dataset *models.Dataset, url string) templ.Compo
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\"><i class=\"if if-eye\"></i> <span>View dataset</span></a><div class=\"dropdown-divider\"></div>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\"><i class=\"if if-eye\"></i> <span>View dataset</span></a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -73,7 +73,7 @@ func SummaryActions(c *ctx.Ctx, dataset *models.Dataset, url string) templ.Compo
 			}
 		}
 		if c.User.CanDeleteDataset(dataset) {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"dropdown-divider\"></div><button class=\"dropdown-item\" hx-get=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<button class=\"dropdown-item border-top\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/views/dataset/suggest_departments.templ
+++ b/views/dataset/suggest_departments.templ
@@ -10,29 +10,34 @@ templ SuggestDepartments(c *ctx.Ctx, dataset *models.Dataset, hits []models.Comp
 	<ul class="list-group mt-6">
 		for _, hit := range hits {
 			<li class="list-group-item">
-				<div class="d-flex w-100">
-					<div class="w-100">
-						<div class="d-flex align-items-start">
-							<div class="list-group-item-content">
-								<div class="list-group-item-text">
-									<h4 class="c-h4">{ hit.Heading }</h4>
-									<div class="c-body-small text-muted">{ hit.Description }</div>
-									<div class="text-muted c-body-small">Department ID: { hit.ID }</div>
+				<div class="list-group-item-inner">
+					<div class="list-group-item-main">
+						<div class="d-flex align-items-top">
+							<div class="mx-3">
+								<div class="mb-3">
+									<h3>{ hit.Heading }</h3>
 								</div>
-								<div class="list-group-item-meta mt-2">
-									<div class="list-group-item-meta-left"></div>
-									<div class="list-group-item-meta-right">
-										<button
-											class="btn btn-primary"
-											hx-post={ c.PathTo("dataset_create_department", "id", dataset.ID).String() }
-											hx-headers={ fmt.Sprintf(`{"If-Match": "%s"}`, dataset.SnapshotID) }
-											hx-vals={ fmt.Sprintf(`{"department_id": "%s"}`, hit.ID) }
-											hx-swap="none"
-										>Add department</button>
-									</div>
+								<div class="mb-3">
+									<ul class="c-meta-list c-meta-list-horizontal">
+										<li class="c-meta-item gap-4">
+											<div>
+												<span>Department ID</span>
+												<code class="c-code d-inline-block">{ hit.ID }</code>
+											</div>
+										</li>
+									</ul>
 								</div>
 							</div>
 						</div>
+					</div>
+					<div class="c-button-toolbar">
+						<button
+							class="btn btn-primary"
+							hx-post={ c.PathTo("dataset_create_department", "id", dataset.ID).String() }
+							hx-headers={ fmt.Sprintf(`{"If-Match": "%s"}`, dataset.SnapshotID) }
+							hx-vals={ fmt.Sprintf(`{"department_id": "%s"}`, hit.ID) }
+							hx-swap="none"
+						>Add department</button>
 					</div>
 				</div>
 			</li>

--- a/views/dataset/suggest_departments_templ.go
+++ b/views/dataset/suggest_departments_templ.go
@@ -34,46 +34,33 @@ func SuggestDepartments(c *ctx.Ctx, dataset *models.Dataset, hits []models.Compl
 			return templ_7745c5c3_Err
 		}
 		for _, hit := range hits {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<li class=\"list-group-item\"><div class=\"d-flex w-100\"><div class=\"w-100\"><div class=\"d-flex align-items-start\"><div class=\"list-group-item-content\"><div class=\"list-group-item-text\"><h4 class=\"c-h4\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<li class=\"list-group-item\"><div class=\"list-group-item-inner\"><div class=\"list-group-item-main\"><div class=\"d-flex align-items-top\"><div class=\"mx-3\"><div class=\"mb-3\"><h3>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(hit.Heading)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/suggest_departments.templ`, Line: 17, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/suggest_departments.templ`, Line: 17, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</h4><div class=\"c-body-small text-muted\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</h3></div><div class=\"mb-3\"><ul class=\"c-meta-list c-meta-list-horizontal\"><li class=\"c-meta-item gap-4\"><div><span>Department ID</span> <code class=\"c-code d-inline-block\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(hit.Description)
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(hit.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/suggest_departments.templ`, Line: 18, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/suggest_departments.templ`, Line: 24, Col: 56}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div class=\"text-muted c-body-small\">Department ID: ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var4 string
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(hit.ID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `dataset/suggest_departments.templ`, Line: 19, Col: 69}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div></div><div class=\"list-group-item-meta mt-2\"><div class=\"list-group-item-meta-left\"></div><div class=\"list-group-item-meta-right\"><button class=\"btn btn-primary\" hx-post=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</code></div></li></ul></div></div></div></div><div class=\"c-button-toolbar\"><button class=\"btn btn-primary\" hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -97,7 +84,7 @@ func SuggestDepartments(c *ctx.Ctx, dataset *models.Dataset, hits []models.Compl
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-swap=\"none\">Add department</button></div></div></div></div></div></div></li>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-swap=\"none\">Add department</button></div></div></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/views/dataset/summary/summary.templ
+++ b/views/dataset/summary/summary.templ
@@ -162,7 +162,7 @@ templ Summary(c *ctx.Ctx, args SummaryArgs) {
 								}
 							</ul>
 							@contributorviews.Summary(c, contributorviews.SummaryArgs{
-								Role:             "author",
+								Role:             "creator",
 								Contributors:     args.Dataset.Author,
 								URL:              views.URL(args.URL).SetQueryParam("show", "contributors").String(),
 								URLTarget:        args.Target,

--- a/views/dataset/summary/summary_templ.go
+++ b/views/dataset/summary/summary_templ.go
@@ -496,7 +496,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = contributorviews.Summary(c, contributorviews.SummaryArgs{
-			Role:             "author",
+			Role:             "creator",
 			Contributors:     args.Dataset.Author,
 			URL:              views.URL(args.URL).SetQueryParam("show", "contributors").String(),
 			URLTarget:        args.Target,

--- a/views/publication/search_hit.templ
+++ b/views/publication/search_hit.templ
@@ -16,11 +16,10 @@ templ SummaryActions(c *ctx.Ctx, pub *models.Publication, pubURL *url.URL) {
 				<span class="visually-hidden">View more actions</span>
 			</button>
 			<div class="dropdown-menu me-3">
-				<a class="dropdown-item" href={ templ.URL(pubURL.String()) }>
+				<a class="dropdown-item border-bottom" href={ templ.URL(pubURL.String()) }>
 					<i class="if if-eye"></i>
 					<span>View publication</span>
 				</a>
-				<div class="dropdown-divider"></div>
 				if pub.Status == "public" {
 					<a class="dropdown-item" href={ templ.URL(fmt.Sprintf("%s/publication/%s", c.FrontendURL, pub.ID)) } target="_blank">
 						<i class="if if-book"></i>
@@ -59,9 +58,8 @@ templ SummaryActions(c *ctx.Ctx, pub *models.Publication, pubURL *url.URL) {
 					}
 				}
 				if c.User.CanDeletePublication(pub) {
-					<div class="dropdown-divider"></div>
 					<button
-						class="dropdown-item"
+						class="dropdown-item border-top"
 						hx-get={ views.URL(c.PathTo("publication_confirm_delete", "id", pub.ID)).SetQueryParam("redirect-url", c.CurrentURL.String()).String() }
 						hx-target="#modals"
 					>

--- a/views/publication/search_hit_templ.go
+++ b/views/publication/search_hit_templ.go
@@ -30,7 +30,7 @@ func SummaryActions(c *ctx.Ctx, pub *models.Publication, pubURL *url.URL) templ.
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"c-button-toolbar\"><div class=\"dropdown\"><button class=\"btn btn-tertiary btn-lg-only-responsive pt-0\" type=\"button\" data-bs-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"><i class=\"if if-more\"></i> <span class=\"btn-text d-md-none d-lg-inline-block\">Actions</span> <span class=\"visually-hidden\">View more actions</span></button><div class=\"dropdown-menu me-3\"><a class=\"dropdown-item\" href=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"c-button-toolbar\"><div class=\"dropdown\"><button class=\"btn btn-tertiary btn-lg-only-responsive pt-0\" type=\"button\" data-bs-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"><i class=\"if if-more\"></i> <span class=\"btn-text d-md-none d-lg-inline-block\">Actions</span> <span class=\"visually-hidden\">View more actions</span></button><div class=\"dropdown-menu me-3\"><a class=\"dropdown-item border-bottom\" href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -39,7 +39,7 @@ func SummaryActions(c *ctx.Ctx, pub *models.Publication, pubURL *url.URL) templ.
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\"><i class=\"if if-eye\"></i> <span>View publication</span></a><div class=\"dropdown-divider\"></div>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\"><i class=\"if if-eye\"></i> <span>View publication</span></a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -143,7 +143,7 @@ func SummaryActions(c *ctx.Ctx, pub *models.Publication, pubURL *url.URL) templ.
 			}
 		}
 		if c.User.CanDeletePublication(pub) {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"dropdown-divider\"></div><button class=\"dropdown-item\" hx-get=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<button class=\"dropdown-item border-top\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/views/publication/suggest_departments.templ
+++ b/views/publication/suggest_departments.templ
@@ -10,29 +10,34 @@ templ SuggestDepartments(c *ctx.Ctx, publication *models.Publication, hits []mod
 	<ul class="list-group mt-6">
 		for _, hit := range hits {
 			<li class="list-group-item">
-				<div class="d-flex w-100">
-					<div class="w-100">
-						<div class="d-flex align-items-start">
-							<div class="list-group-item-content">
-								<div class="list-group-item-text">
-									<h4 class="c-h4">{ hit.Heading }</h4>
-									<div class="c-body-small text-muted">{ hit.Description }</div>
-									<div class="text-muted c-body-small">Department ID: { hit.ID }</div>
+				<div class="list-group-item-inner">
+					<div class="list-group-item-main">
+						<div class="d-flex align-items-top">
+							<div class="mx-3">
+								<div class="mb-3">
+									<h3>{ hit.Heading }</h3>
 								</div>
-								<div class="list-group-item-meta mt-2">
-									<div class="list-group-item-meta-left"></div>
-									<div class="list-group-item-meta-right">
-										<button
-											class="btn btn-primary"
-											hx-post={ c.PathTo("publication_create_department", "id", publication.ID).String() }
-											hx-headers={ fmt.Sprintf(`{"If-Match": "%s"}`, publication.SnapshotID) }
-											hx-vals={ fmt.Sprintf(`{"department_id": "%s"}`, hit.ID) }
-											hx-swap="none"
-										>Add department</button>
-									</div>
+								<div class="mb-3">
+									<ul class="c-meta-list c-meta-list-horizontal">
+										<li class="c-meta-item gap-4">
+											<div>
+												<span>Department ID</span>
+												<code class="c-code d-inline-block">{ hit.ID }</code>
+											</div>
+										</li>
+									</ul>
 								</div>
 							</div>
 						</div>
+					</div>
+					<div class="c-button-toolbar">
+						<button
+							class="btn btn-primary"
+							hx-post={ c.PathTo("publication_create_department", "id", publication.ID).String() }
+							hx-headers={ fmt.Sprintf(`{"If-Match": "%s"}`, publication.SnapshotID) }
+							hx-vals={ fmt.Sprintf(`{"department_id": "%s"}`, hit.ID) }
+							hx-swap="none"
+						>Add department</button>
 					</div>
 				</div>
 			</li>

--- a/views/publication/suggest_departments_templ.go
+++ b/views/publication/suggest_departments_templ.go
@@ -34,46 +34,33 @@ func SuggestDepartments(c *ctx.Ctx, publication *models.Publication, hits []mode
 			return templ_7745c5c3_Err
 		}
 		for _, hit := range hits {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<li class=\"list-group-item\"><div class=\"d-flex w-100\"><div class=\"w-100\"><div class=\"d-flex align-items-start\"><div class=\"list-group-item-content\"><div class=\"list-group-item-text\"><h4 class=\"c-h4\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<li class=\"list-group-item\"><div class=\"list-group-item-inner\"><div class=\"list-group-item-main\"><div class=\"d-flex align-items-top\"><div class=\"mx-3\"><div class=\"mb-3\"><h3>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(hit.Heading)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/suggest_departments.templ`, Line: 17, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/suggest_departments.templ`, Line: 17, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</h4><div class=\"c-body-small text-muted\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</h3></div><div class=\"mb-3\"><ul class=\"c-meta-list c-meta-list-horizontal\"><li class=\"c-meta-item gap-4\"><div><span>Department ID</span> <code class=\"c-code d-inline-block\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(hit.Description)
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(hit.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/suggest_departments.templ`, Line: 18, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/suggest_departments.templ`, Line: 24, Col: 56}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div class=\"text-muted c-body-small\">Department ID: ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var4 string
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(hit.ID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/suggest_departments.templ`, Line: 19, Col: 69}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div></div><div class=\"list-group-item-meta mt-2\"><div class=\"list-group-item-meta-left\"></div><div class=\"list-group-item-meta-right\"><button class=\"btn btn-primary\" hx-post=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</code></div></li></ul></div></div></div></div><div class=\"c-button-toolbar\"><button class=\"btn btn-primary\" hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -97,7 +84,7 @@ func SuggestDepartments(c *ctx.Ctx, publication *models.Publication, hits []mode
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-swap=\"none\">Add department</button></div></div></div></div></div></div></li>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" hx-swap=\"none\">Add department</button></div></div></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/views/publication/summary/summary.templ
+++ b/views/publication/summary/summary.templ
@@ -32,6 +32,10 @@ func getUserContributorRoles(p *models.Publication, user *models.Person) string 
 		roles = append(roles, "supervisor")
 	}
 
+	if p.HasContributor("editor", user) {
+		roles = append(roles, "editor")
+	}
+
 	if len(roles) > 0 {
 		return strings.Join(roles, ", ")
 	}
@@ -154,13 +158,26 @@ templ Summary(c *ctx.Ctx, args SummaryArgs) {
 									<li class="c-meta-item">{ summaryPart }</li>
 								}
 							</ul>
-							@contributorviews.Summary(c, contributorviews.SummaryArgs{
-								Role:             "author",
-								Contributors:     args.Publication.Author,
-								URL:              views.URL(args.URL).SetQueryParam("show", "contributors").String(),
-								URLTarget:        args.Target,
-								CurrentUserRoles: getUserContributorRoles(args.Publication, c.User),
-							})
+
+							if (args.Publication.Type != "issue_editor") && (args.Publication.Type != "book_editor") {
+								@contributorviews.Summary(c, contributorviews.SummaryArgs{
+									Role:             "author",
+									Contributors:     args.Publication.Author,
+									URL:              views.URL(args.URL).SetQueryParam("show", "contributors").String(),
+									URLTarget:        args.Target,
+									CurrentUserRoles: getUserContributorRoles(args.Publication, c.User),
+								})
+							} else if getUserContributorRoles(args.Publication, c.User) != "" {
+								<div class="d-flex align-items-center">
+									<i class="if if-user if--small if--muted me-2"></i>
+									<ul class="c-meta-list c-meta-list-inline">
+										<li class="c-meta-item">
+											<span class="badge badge-light">Your role: { getUserContributorRoles(args.Publication, c.User)}</span>
+										</li>
+									</ul>
+								</div>
+							}
+
 						</div>
 						<div class="vstack gap-3">
 							<div class="d-flex align-items-center">
@@ -170,8 +187,8 @@ templ Summary(c *ctx.Ctx, args SummaryArgs) {
 									@relatedorganizationviews.Summary(c, args.Publication.RelatedOrganizations, views.URL(args.URL).SetQueryParam("show", "contributors").String())
 								} else {
 									<a
-										href={ views.URL(args.URL).SetQueryParam("show", "contributors").SafeURL() }
 										class="c-link-muted"
+										href={ views.URL(args.URL).SetQueryParam("show", "contributors").SafeURL() }
 										if args.Target != "" {
 											target={ args.Target }
 										}

--- a/views/publication/summary/summary_templ.go
+++ b/views/publication/summary/summary_templ.go
@@ -42,6 +42,10 @@ func getUserContributorRoles(p *models.Publication, user *models.Person) string 
 		roles = append(roles, "supervisor")
 	}
 
+	if p.HasContributor("editor", user) {
+		roles = append(roles, "editor")
+	}
+
 	if len(roles) > 0 {
 		return strings.Join(roles, ", ")
 	}
@@ -125,7 +129,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%s: %s", c.Loc.Get("publication_types."+args.Publication.Type), args.Publication.Classification))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 73, Col: 123}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 77, Col: 123}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -135,7 +139,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(c.Loc.Get("publication_types." + args.Publication.Type))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 75, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 79, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -172,7 +176,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(c.Loc.Get("publication_file_access_levels." + mainFile.AccessLevel))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 82, Col: 118}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 86, Col: 118}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -190,7 +194,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(c.Loc.Get("publication_file_access_levels." + mainFile.AccessLevel))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 85, Col: 115}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 89, Col: 115}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -208,7 +212,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(c.Loc.Get("publication_file_access_levels." + mainFile.AccessLevel))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 88, Col: 115}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 92, Col: 115}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -226,7 +230,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(c.Loc.Get("publication_file_access_levels." + mainFile.AccessLevel))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 91, Col: 115}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 95, Col: 115}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
@@ -264,7 +268,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(c.Loc.Get("publication_file_access_levels_during_embargo." + mainFile.AccessLevelDuringEmbargo))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 101, Col: 146}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 105, Col: 146}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -288,7 +292,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(c.Loc.Get("publication_file_access_levels_after_embargo." + mainFile.AccessLevelAfterEmbargo))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 109, Col: 106}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 113, Col: 106}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -301,7 +305,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(mainFile.EmbargoDate)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 109, Col: 136}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 113, Col: 136}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -354,7 +358,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(args.Publication.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 130, Col: 34}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 134, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -402,7 +406,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(args.Publication.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 143, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 147, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
@@ -431,7 +435,7 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(summaryPart)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 153, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 157, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -446,15 +450,35 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = contributorviews.Summary(c, contributorviews.SummaryArgs{
-			Role:             "author",
-			Contributors:     args.Publication.Author,
-			URL:              views.URL(args.URL).SetQueryParam("show", "contributors").String(),
-			URLTarget:        args.Target,
-			CurrentUserRoles: getUserContributorRoles(args.Publication, c.User),
-		}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
+		if (args.Publication.Type != "issue_editor") && (args.Publication.Type != "book_editor") {
+			templ_7745c5c3_Err = contributorviews.Summary(c, contributorviews.SummaryArgs{
+				Role:             "author",
+				Contributors:     args.Publication.Author,
+				URL:              views.URL(args.URL).SetQueryParam("show", "contributors").String(),
+				URLTarget:        args.Target,
+				CurrentUserRoles: getUserContributorRoles(args.Publication, c.User),
+			}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if getUserContributorRoles(args.Publication, c.User) != "" {
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"d-flex align-items-center\"><i class=\"if if-user if--small if--muted me-2\"></i><ul class=\"c-meta-list c-meta-list-inline\"><li class=\"c-meta-item\"><span class=\"badge badge-light\">Your role: ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var18 string
+			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(getUserContributorRoles(args.Publication, c.User))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 174, Col: 105}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</span></li></ul></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div class=\"vstack gap-3\"><div class=\"d-flex align-items-center\"><i class=\"if if-building if--small if--muted me-2\"></i> ")
 		if templ_7745c5c3_Err != nil {
@@ -470,16 +494,16 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<a href=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<a class=\"c-link-muted\" href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var18 templ.SafeURL = views.URL(args.URL).SetQueryParam("show", "contributors").SafeURL()
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var18)))
+			var templ_7745c5c3_Var19 templ.SafeURL = views.URL(args.URL).SetQueryParam("show", "contributors").SafeURL()
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var19)))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\" class=\"c-link-muted\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -517,12 +541,12 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var19 string
-					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(vabb)
+					var templ_7745c5c3_Var20 string
+					templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(vabb)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 191, Col: 49}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 208, Col: 49}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -564,12 +588,12 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var20 string
-				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", len(args.Publication.RelatedDataset)))
+				var templ_7745c5c3_Var21 string
+				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", len(args.Publication.RelatedDataset)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 209, Col: 93}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 226, Col: 93}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -593,12 +617,12 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(views.CreatedBy(c, args.Publication.DateCreated, args.Publication.Creator))
+		var templ_7745c5c3_Var22 string
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(views.CreatedBy(c, args.Publication.DateCreated, args.Publication.Creator))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 221, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 238, Col: 85}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -606,12 +630,12 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(views.UpdatedBy(c, args.Publication.DateUpdated, args.Publication.User, args.Publication.LastUser))
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(views.UpdatedBy(c, args.Publication.DateUpdated, args.Publication.User, args.Publication.LastUser))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 224, Col: 109}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 241, Col: 109}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -627,12 +651,12 @@ func Summary(c *ctx.Ctx, args SummaryArgs) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var23 string
-		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(args.Publication.ID)
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(args.Publication.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 233, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `publication/summary/summary.templ`, Line: 250, Col: 51}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Fixes "Add Authors / Creators" temporarily:

Datasets
- For datasets it no longer says "Add author" but "Add creator" in line with the roles
![Screenshot 2024-06-26 at 18 01 05](https://github.com/ugent-library/biblio-backoffice/assets/1572885/c3094e65-63cd-4116-ac15-e96820a2d467)

Publications
- For publications it no longer says "Add author" for issue editors and book editors. This is not ideal, as we should nudge to add editors, but the call to action would never go away as those publication types do not have authors at all.
  - what it looks like for editor publication types: ![Screenshot 2024-06-26 at 18 02 05](https://github.com/ugent-library/biblio-backoffice/assets/1572885/deb4803e-7e41-4601-b8ba-1e116e548dda)
  - what it looks like for others: 
![Screenshot 2024-06-26 at 18 03 02](https://github.com/ugent-library/biblio-backoffice/assets/1572885/899c7a5a-8fde-449b-9877-ed099cb6a520)

## Other fixes

- Aligns badges
- Circumvents annoying double lines (See #1623)
- Aligns "Add department" to "Add projects" behaviour
- Removes superfluous code for departments
